### PR TITLE
feat: add Gemini 3.7 Flash model support

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -2010,6 +2010,14 @@ const MODEL_CATALOG = [
     tools: true,
   },
   {
+    id: "gemini-3.7-flash-tiered",
+    family: "gemini-3.7-flash",
+    ctx: 1048576,
+    quotaPool: "gemini",
+    multimodal: true,
+    tools: true,
+  },
+  {
     id: "gemini-3.1-pro-low",
     family: "gemini-3.1-pro",
     ctx: 1048576,

--- a/src/compat/model-specs.ts
+++ b/src/compat/model-specs.ts
@@ -21,6 +21,7 @@ export const DEFAULT_MODEL_SPECS: Record<string, ModelSpec> = {
 	"gemini-3.6-flash-medium":   { maxOutputTokens: 65536, thinkingBudget: 4000,  isThinking: true },
 	"gemini-3.6-flash-low":      { maxOutputTokens: 65536, thinkingBudget: 1000,  isThinking: true },
 	"gemini-3.6-flash-tiered":   { maxOutputTokens: 65536, thinkingBudget: -1,    isThinking: true },
+	"gemini-3.7-flash-tiered":   { maxOutputTokens: 65536, thinkingBudget: -1,    isThinking: true },
 	"gemini-3-flash":            { maxOutputTokens: 65536, thinkingBudget: 4000,  isThinking: true },
 	"gemini-2.5-flash":          { maxOutputTokens: 65535, thinkingBudget: 24576, isThinking: true },
 	"gemini-2.5-pro":            { maxOutputTokens: 65535, thinkingBudget: 1024,  isThinking: true },

--- a/src/providers/google-antigravity/translators.ts
+++ b/src/providers/google-antigravity/translators.ts
@@ -836,6 +836,38 @@ export function convertResponsesToChatRequest(
   };
 }
 
+/**
+ * Canonical model ID whose thinking level follows an OpenAI-style
+ * reasoning_effort. Matched case-insensitively against the exact ID only;
+ * virtual siblings (e.g. `gemini-3.7-flash-tiered-high`) are excluded.
+ */
+export const TIERED_EFFORT_MODEL_ID = "gemini-3.7-flash-tiered";
+
+/**
+ * Map an OpenAI Chat `reasoning_effort` to a Gemini `thinkingLevel` for
+ * `gemini-3.7-flash-tiered` only. Accepts exactly low/medium/high
+ * (case-insensitive); anything else returns undefined so the caller falls
+ * back to the existing adaptive/fixed-budget semantics and never emits an
+ * invalid upstream enum.
+ */
+export function mapTieredReasoningEffortToThinkingLevel(
+  effort: string | undefined,
+  modelId: string,
+): "LOW" | "MEDIUM" | "HIGH" | undefined {
+  if (modelId.toLowerCase() !== TIERED_EFFORT_MODEL_ID) return undefined;
+  if (!isNonEmptyString(effort)) return undefined;
+  switch (effort.toLowerCase()) {
+    case "low":
+      return "LOW";
+    case "medium":
+      return "MEDIUM";
+    case "high":
+      return "HIGH";
+    default:
+      return undefined;
+  }
+}
+
 export function openAIToAntigravityBody(
   input: OpenAIChatCompletionRequest,
 ): RequestBody {
@@ -1155,10 +1187,28 @@ export function openAIToAntigravityBody(
     }
   } else if (isThinking && modelFamily !== "claude") {
     const tb = modelSpec.thinkingBudget;
-    thinkingConfigObj =
+    // Only the exact tiered model selects its thinking level from an
+    // OpenAI-style reasoning_effort, and only while its spec stays adaptive
+    // (thinkingBudget === -1). A fixed budget — bundled or set by an operator
+    // modelSpecs override — deterministically wins and is never combined
+    // with thinkingLevel.
+    const tieredThinkingLevel =
       tb === -1
-        ? { includeThoughts: true }
-        : { includeThoughts: true, thinkingBudget: tb };
+        ? mapTieredReasoningEffortToThinkingLevel(
+            input.reasoning_effort,
+            input.model,
+          )
+        : undefined;
+    if (tieredThinkingLevel) {
+      thinkingConfigObj = {
+        includeThoughts: true,
+        thinkingLevel: tieredThinkingLevel,
+      };
+    } else if (tb === -1) {
+      thinkingConfigObj = { includeThoughts: true };
+    } else {
+      thinkingConfigObj = { includeThoughts: true, thinkingBudget: tb };
+    }
     if (tb !== -1 && (!maxOutputTokens || maxOutputTokens <= tb)) {
       maxOutputTokens = Math.min(tb + 8192, modelSpec.maxOutputTokens);
       compatLogger.debug(

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -2352,6 +2352,7 @@ export class AccountRotator {
         const lower = model.toLowerCase();
         if (lower.includes("opus")) pricing = MODEL_PRICING["claude-opus-4-6-thinking"];
         else if (lower.includes("sonnet")) pricing = MODEL_PRICING["claude-sonnet-4-6"];
+        else if (lower.includes("3.7-flash")) pricing = MODEL_PRICING["gemini-3.7-flash-tiered"];
         else if (lower.includes("3.6-flash")) pricing = MODEL_PRICING["gemini-3.6-flash-high"];
         else if (lower.includes("3.5-flash")) pricing = MODEL_PRICING["gemini-3.5-flash-high"];
         else if (lower.includes("flash")) pricing = MODEL_PRICING["gemini-3-flash"];

--- a/src/spend-logger.ts
+++ b/src/spend-logger.ts
@@ -223,6 +223,8 @@ export function calculateCost(model: string, promptTokens: number, completionTok
       pricing = MODEL_PRICING["claude-opus-4-6-thinking"];
     } else if (lower.includes("sonnet")) {
       pricing = MODEL_PRICING["claude-sonnet-4-6"];
+    } else if (lower.includes("3.7-flash")) {
+      pricing = MODEL_PRICING["gemini-3.7-flash-tiered"];
     } else if (lower.includes("3.6-flash")) {
       pricing = MODEL_PRICING["gemini-3.6-flash-high"];
     } else if (lower.includes("3.5-flash")) {

--- a/src/static/dashboard-keys.js
+++ b/src/static/dashboard-keys.js
@@ -258,6 +258,7 @@ var FALLBACK_MODEL_CATALOG = [
   { id: "gemini-3.6-flash-medium", owned_by: "tuxevil-rotator" },
   { id: "gemini-3.6-flash-high", owned_by: "tuxevil-rotator" },
   { id: "gemini-3.6-flash-tiered", owned_by: "tuxevil-rotator" },
+  { id: "gemini-3.7-flash-tiered", owned_by: "tuxevil-rotator" },
   { id: "claude-sonnet-4-6", owned_by: "tuxevil-rotator" },
   { id: "claude-opus-4-6-thinking", owned_by: "tuxevil-rotator" },
   { id: "gpt-oss-120b-medium", owned_by: "tuxevil-rotator" },

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -1168,6 +1168,10 @@ var MODEL_PRICING_CLIENT = {
   "gemini-3.6-flash-medium": { input: 1.5, output: 7.5 },
   "gemini-3.6-flash-low": { input: 1.5, output: 7.5 },
   "gemini-3.6-flash-tiered": { input: 1.5, output: 7.5 },
+  // Gemini 3.7 Flash tiered — public Gemini API pricing, verified 2026-08-13.
+  // Introductory rates through 2026-12-31; from 2027-01-01 these double to
+  // input 1.50 / output 7.50 per 1M tokens — update this entry then.
+  "gemini-3.7-flash-tiered": { input: 0.75, output: 3.75 },
   "gpt-oss-120b-medium": { input: 2.0, output: 10.0 },
   // OpenAI Codex GPT-5.6 models — mirrors MODEL_PRICING in types.ts.
   "gpt-5.6-sol": { input: 5.0, output: 30.0 },
@@ -1207,6 +1211,7 @@ function getModelPricingClient(m) {
   var lower = (m || "").toLowerCase();
   if (lower.indexOf("opus") !== -1) return MODEL_PRICING_CLIENT["claude-opus-4-6-thinking"];
   if (lower.indexOf("sonnet") !== -1) return MODEL_PRICING_CLIENT["claude-sonnet-4-6"];
+  if (lower.indexOf("3.7-flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.7-flash-tiered"];
   if (lower.indexOf("3.6-flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.6-flash-high"];
   if (lower.indexOf("3.5-flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.5-flash-high"];
   if (lower.indexOf("flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3-flash"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,6 +277,7 @@ export const QUOTA_MODEL_KEYS: Record<
       "gemini-3.6-flash-medium",
       "gemini-3.6-flash-low",
       "gemini-3.6-flash-tiered",
+      "gemini-3.7-flash-tiered",
     ],
     display: "Gemini",
   },
@@ -344,6 +345,17 @@ export function resolveDisplayModelKey(requestModel: string): string {
     if (lower.includes("-tiered")) return "gemini-3.6-flash-tiered";
     if (lower.includes("-high")) return "gemini-3.6-flash-high";
     return "gemini-3.6-flash-high"; // unspecified variant
+  }
+  // Gemini 3.7 Flash — only the tiered variant exists. Unsupported
+  // virtual variants (low/medium/high) intentionally fall through to the
+  // generic Flash fallback below instead of resolving as supported models.
+  if (
+    lower.includes("gemini") &&
+    lower.includes("3.7") &&
+    lower.includes("flash") &&
+    lower.includes("-tiered")
+  ) {
+    return "gemini-3.7-flash-tiered";
   }
   // Gemini 3.5 Flash — distinguish medium vs high
   if (
@@ -752,6 +764,18 @@ export const MODEL_PRICING: Record<
     outputPer1M: 7.5,
     cachingPer1M: 0.15,
     cachingStoragePer1MPerHour: 1.0,
+  },
+  // Gemini 3.7 Flash tiered — public Gemini API equivalent-value pricing,
+  // verified on the official Gemini API / Google Cloud pricing pages
+  // 2026-08-13. Introductory rates through 2026-12-31. From 2027-01-01
+  // these double to: input 1.50, output 7.50, cached input 0.15, cache
+  // storage 1.00 (USD per 1M tokens / per 1M tokens/hour) — update this
+  // static entry when the introductory period ends.
+  "gemini-3.7-flash-tiered": {
+    inputPer1M: 0.75,
+    outputPer1M: 3.75,
+    cachingPer1M: 0.075,
+    cachingStoragePer1MPerHour: 0.5,
   },
   "gpt-oss-120b-medium": { inputPer1M: 2.0, outputPer1M: 10.0 },
 

--- a/test/compat-translators.test.ts
+++ b/test/compat-translators.test.ts
@@ -1,16 +1,22 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import {
 	openAIToAntigravityBody,
 	anthropicToAntigravityBody,
 	normalizeOpenAIChatCompletionRequest,
 	normalizeOpenAIResponsesRequest,
+	mapTieredReasoningEffortToThinkingLevel,
 } from "../src/providers/google-antigravity/translators.js";
+import { setModelSpecsOverride } from "../src/compat/model-specs.js";
 
 type AntigravityBodyWithRequest = ReturnType<typeof openAIToAntigravityBody> & {
 	request: {
 		systemInstruction?: unknown;
 		contents?: unknown;
+		generationConfig?: {
+			maxOutputTokens?: number;
+			thinkingConfig?: Record<string, unknown>;
+		};
 	};
 };
 
@@ -70,5 +76,197 @@ describe("translators component", () => {
 		assert.deepEqual(normalized.messages, [
 			{ role: "user", content: [{ type: "text", text: "hola" }] },
 		]);
+	});
+});
+
+describe("gemini-3.7-flash-tiered thinkingLevel mapping", () => {
+	afterEach(() => {
+		setModelSpecsOverride(null);
+	});
+
+	it("maps low/medium/high reasoning_effort to thinkingLevel for the exact tiered model", () => {
+		const cases: Array<[string, string]> = [
+			["low", "LOW"],
+			["medium", "MEDIUM"],
+			["high", "HIGH"],
+		];
+		for (const [effort, level] of cases) {
+			const body = openAIToAntigravityBody({
+				model: "gemini-3.7-flash-tiered",
+				messages: [{ role: "user", content: "ping" }],
+				reasoning_effort: effort,
+			}) as AntigravityBodyWithRequest;
+			assert.deepEqual(body.request.generationConfig?.thinkingConfig, {
+				includeThoughts: true,
+				thinkingLevel: level,
+			});
+		}
+	});
+
+	it("matches the canonical model id case-insensitively", () => {
+		const body = openAIToAntigravityBody({
+			model: "Gemini-3.7-Flash-Tiered",
+			messages: [{ role: "user", content: "ping" }],
+			reasoning_effort: "HIGH",
+		}) as AntigravityBodyWithRequest;
+		assert.deepEqual(body.request.generationConfig?.thinkingConfig, {
+			includeThoughts: true,
+			thinkingLevel: "HIGH",
+		});
+	});
+
+	it("emits adaptive includeThoughts only when no effort is supplied", () => {
+		const body = openAIToAntigravityBody({
+			model: "gemini-3.7-flash-tiered",
+			messages: [{ role: "user", content: "ping" }],
+		}) as AntigravityBodyWithRequest;
+		assert.deepEqual(body.request.generationConfig?.thinkingConfig, {
+			includeThoughts: true,
+		});
+	});
+
+	it("does not emit thinkingLevel for virtual tiered siblings", () => {
+		for (const model of [
+			"gemini-3.7-flash-tiered-high",
+			"gemini-3.7-flash-tiered-medium",
+			"gemini-3.7-flash-tiered-low",
+		]) {
+			const body = openAIToAntigravityBody({
+				model,
+				messages: [{ role: "user", content: "ping" }],
+				reasoning_effort: "high",
+			}) as AntigravityBodyWithRequest;
+			const tc = body.request.generationConfig?.thinkingConfig;
+			assert.equal(tc?.thinkingLevel, undefined);
+			assert.equal(tc?.thinkingBudget, undefined);
+			assert.equal(tc?.includeThoughts, true);
+		}
+	});
+
+	it("ignores unsupported effort values without emitting an invalid enum", () => {
+		for (const effort of ["minimal", "none", "Fast", "MINIMAL", "", undefined]) {
+			const body = openAIToAntigravityBody({
+				model: "gemini-3.7-flash-tiered",
+				messages: [{ role: "user", content: "ping" }],
+				...(effort !== undefined ? { reasoning_effort: effort } : {}),
+			}) as AntigravityBodyWithRequest;
+			assert.deepEqual(body.request.generationConfig?.thinkingConfig, {
+				includeThoughts: true,
+			});
+		}
+	});
+
+	it("keeps gemini-3.6-flash-high on fixed thinkingBudget 10000 with no thinkingLevel", () => {
+		const body = openAIToAntigravityBody({
+			model: "gemini-3.6-flash-high",
+			messages: [{ role: "user", content: "ping" }],
+			reasoning_effort: "high",
+		}) as AntigravityBodyWithRequest;
+		const tc = body.request.generationConfig?.thinkingConfig;
+		assert.equal(tc?.thinkingBudget, 10000);
+		assert.equal(tc?.thinkingLevel, undefined);
+	});
+
+	it("does not change other models' effort handling", () => {
+		const body = openAIToAntigravityBody({
+			model: "gemini-3.5-flash",
+			messages: [{ role: "user", content: "ping" }],
+			reasoning_effort: "high",
+		}) as AntigravityBodyWithRequest;
+		const tc = body.request.generationConfig?.thinkingConfig;
+		assert.equal(tc?.thinkingLevel, undefined);
+		assert.equal(tc?.thinkingBudget, 10000);
+	});
+
+	it("keeps Anthropic requests on the tiered model adaptive without a thinkingLevel", () => {
+		const body = anthropicToAntigravityBody({
+			model: "gemini-3.7-flash-tiered",
+			system: "be terse",
+			messages: [{ role: "user", content: "ping" }],
+		}) as AntigravityBodyWithRequest;
+		const tc = body.request.generationConfig?.thinkingConfig;
+		// deepStrictEqual requires the exact key set: a thinkingLevel or
+		// thinkingBudget key present would fail this assertion.
+		assert.deepEqual(tc, { includeThoughts: true });
+	});
+
+	it("prefers a fixed operator thinkingBudget override over reasoning_effort", () => {
+		setModelSpecsOverride({
+			"gemini-3.7-flash-tiered": {
+				maxOutputTokens: 65536,
+				thinkingBudget: 7777,
+				isThinking: true,
+			},
+		});
+		const body = openAIToAntigravityBody({
+			model: "gemini-3.7-flash-tiered",
+			messages: [{ role: "user", content: "ping" }],
+			reasoning_effort: "high",
+		}) as AntigravityBodyWithRequest;
+		const tc = body.request.generationConfig?.thinkingConfig;
+		assert.equal(tc?.thinkingBudget, 7777);
+		assert.equal(tc?.thinkingLevel, undefined);
+		assert.equal(tc?.includeThoughts, true);
+	});
+
+	it("restores effort mapping once the fixed override is cleared", () => {
+		setModelSpecsOverride({
+			"gemini-3.7-flash-tiered": {
+				maxOutputTokens: 65536,
+				thinkingBudget: 7777,
+				isThinking: true,
+			},
+		});
+		setModelSpecsOverride(null);
+		const body = openAIToAntigravityBody({
+			model: "gemini-3.7-flash-tiered",
+			messages: [{ role: "user", content: "ping" }],
+			reasoning_effort: "high",
+		}) as AntigravityBodyWithRequest;
+		assert.deepEqual(body.request.generationConfig?.thinkingConfig, {
+			includeThoughts: true,
+			thinkingLevel: "HIGH",
+		});
+	});
+});
+
+describe("mapTieredReasoningEffortToThinkingLevel", () => {
+	it("maps only the exact canonical id and only low/medium/high", () => {
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("low", "gemini-3.7-flash-tiered"),
+			"LOW",
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("MEDIUM", "GEMINI-3.7-FLASH-TIERED"),
+			"MEDIUM",
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("high", "gemini-3.7-flash-tiered"),
+			"HIGH",
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("high", "gemini-3.7-flash-tiered-high"),
+			undefined,
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("minimal", "gemini-3.7-flash-tiered"),
+			undefined,
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel(undefined, "gemini-3.7-flash-tiered"),
+			undefined,
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("high", "gemini-3.7-flash-high"),
+			undefined,
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("high", "gemini-3.6-flash-tiered"),
+			undefined,
+		);
+		assert.equal(
+			mapTieredReasoningEffortToThinkingLevel("high", "gemini-3.6-flash-high"),
+			undefined,
+		);
 	});
 });

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -226,6 +226,69 @@ describe("dashboard", () => {
     assert.equal(savings.byModel["gpt-5.6-luna"].totalUsd, 1.4);
   });
 
+  it("prices gemini-3.7-flash-tiered with its own rates and never falls through to gemini-3-flash", () => {
+    const js = readDashboardJs();
+    const sandbox: Record<string, unknown> = {
+      window: { location: { search: "" } } as Record<string, unknown>,
+      URLSearchParams: globalThis.URLSearchParams,
+      EventSource: function () {},
+      fetch: () => Promise.resolve(),
+      setInterval: () => {},
+      clearInterval: () => {},
+      setTimeout: () => {},
+      clearTimeout: () => {},
+      localStorage: { getItem: () => null, setItem: () => {} },
+      document: {
+        getElementById: () => null,
+        querySelector: () => null,
+        querySelectorAll: () => [],
+        addEventListener: () => {},
+      },
+    };
+    const script = new Script(
+      js +
+        "\nthis.getModelPricingClient = getModelPricingClient;" +
+        "\nthis.calcSavingsFromBuckets = calcSavingsFromBuckets;",
+    );
+    script.runInNewContext(sandbox);
+
+    const getModelPricingClient = sandbox.getModelPricingClient as (
+      m: string,
+    ) => { input: number; output: number } | null;
+    const calcSavingsFromBuckets = sandbox.calcSavingsFromBuckets as (
+      buckets: Array<Record<string, unknown>>,
+    ) => { byModel: Record<string, { totalUsd: number }> };
+
+    // Exact entry
+    const exact = getModelPricingClient("gemini-3.7-flash-tiered");
+    assert.ok(exact);
+    assert.equal(exact.input, 0.75);
+    assert.equal(exact.output, 3.75);
+    // Provider-prefixed id resolves via the 3.7-flash fallback...
+    const prefixed = getModelPricingClient("google/gemini-3.7-flash-tiered");
+    assert.ok(prefixed);
+    assert.equal(prefixed.input, 0.75);
+    assert.equal(prefixed.output, 3.75);
+    // ...and never collapses to the generic gemini-3-flash rates.
+    const legacy = getModelPricingClient("gemini-3-flash");
+    assert.ok(legacy);
+    assert.equal(legacy.input, 0.5);
+    assert.equal(legacy.output, 3.0);
+    assert.notEqual(prefixed.input, legacy.input);
+
+    const savings = calcSavingsFromBuckets([
+      {
+        byModel: {
+          "gemini-3.7-flash-tiered": {
+            inputTokens: 1_000_000,
+            outputTokens: 1_000_000,
+          },
+        },
+      },
+    ]);
+    assert.equal(savings.byModel["gemini-3.7-flash-tiered"].totalUsd, 4.5);
+  });
+
   it("does not offer kickstart controls for Codex quota pools", () => {
     const js = readDashboardJs();
     const sandbox: Record<string, unknown> = {

--- a/test/model-alias.test.ts
+++ b/test/model-alias.test.ts
@@ -50,4 +50,18 @@ describe("applyModelAlias", () => {
 		setModelAliasesOverride(null);
 		assert.equal(applyModelAlias("gemini-3.5-flash-high"), "gemini-3-flash-agent");
 	});
+
+	it("returns gemini-3.7-flash-tiered unchanged (no alias configured)", () => {
+		assert.equal(
+			applyModelAlias("gemini-3.7-flash-tiered"),
+			"gemini-3.7-flash-tiered",
+		);
+	});
+
+	it("creates no aliases for virtual gemini-3.7-flash low/medium/high", () => {
+		for (const variant of ["low", "medium", "high"]) {
+			const id = `gemini-3.7-flash-${variant}`;
+			assert.equal(applyModelAlias(id), id);
+		}
+	});
 });

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { serveGeminiModels, serveOpenAIModels } from "../src/compat.js";
+import { getModelSpec } from "../src/compat/model-specs.js";
 
 function captureJson(render: (res: never) => void): unknown {
 	let raw = "";
@@ -52,5 +53,66 @@ describe("model discovery", () => {
 		const payload = captureJson(serveGeminiModels) as { models: Array<{ supportedGenerationMethods: string[] }> };
 		assert.ok(payload.models.length > 0);
 		assert.deepEqual(payload.models[0].supportedGenerationMethods, ["generateContent", "streamGenerateContent"]);
+	});
+
+	it("exposes gemini-3.7-flash-tiered exactly once in /v1/models with expected metadata", () => {
+		const payload = captureJson(serveOpenAIModels) as {
+			data: Array<{
+				id: string;
+				owned_by: string;
+				context_window: number;
+				meta: Record<string, unknown>;
+			}>;
+		};
+		const entries = payload.data.filter((m) => m.id === "gemini-3.7-flash-tiered");
+		assert.equal(entries.length, 1);
+		const entry = entries[0];
+		assert.equal(entry.owned_by, "tuxevil-rotator");
+		assert.equal(entry.context_window, 1048576);
+		assert.equal(entry.meta.family, "gemini-3.7-flash");
+		assert.equal(entry.meta.quota_pool, "gemini");
+		assert.equal(entry.meta.multimodal, true);
+		assert.equal(entry.meta.tool_calling, true);
+	});
+
+	it("exposes gemini-3.7-flash-tiered exactly once in the gemini catalog with expected metadata", () => {
+		const payload = captureJson(serveGeminiModels) as {
+			models: Array<{
+				name: string;
+				baseModelId: string;
+				inputTokenLimit: number;
+				capabilities: { tools: boolean; multimodal: boolean; quotaPool: string };
+			}>;
+		};
+		const entries = payload.models.filter((m) => m.name === "models/gemini-3.7-flash-tiered");
+		assert.equal(entries.length, 1);
+		const entry = entries[0];
+		assert.equal(entry.baseModelId, "gemini-3.7-flash");
+		assert.equal(entry.inputTokenLimit, 1048576);
+		assert.equal(entry.capabilities.tools, true);
+		assert.equal(entry.capabilities.multimodal, true);
+		assert.equal(entry.capabilities.quotaPool, "gemini");
+	});
+
+	it("creates no virtual gemini-3.7-flash low/medium/high catalog entries", () => {
+		const openAiPayload = captureJson(serveOpenAIModels) as {
+			data: Array<{ id: string }>;
+		};
+		const geminiPayload = captureJson(serveGeminiModels) as {
+			models: Array<{ name: string }>;
+		};
+		for (const variant of ["low", "medium", "high"]) {
+			const id = `gemini-3.7-flash-${variant}`;
+			assert.ok(!openAiPayload.data.some((m) => m.id === id));
+			assert.ok(!geminiPayload.models.some((m) => m.name === `models/${id}`));
+		}
+	});
+
+	it("ships the exact default spec for gemini-3.7-flash-tiered", () => {
+		assert.deepEqual(getModelSpec("gemini-3.7-flash-tiered"), {
+			maxOutputTokens: 65536,
+			thinkingBudget: -1,
+			isThinking: true,
+		});
 	});
 });

--- a/test/model-resolution.test.ts
+++ b/test/model-resolution.test.ts
@@ -6,6 +6,7 @@ import {
 	resolveDisplayModelKey,
 	resolveQuotaModelKey,
 } from "../src/types.js";
+import { extractQuotas } from "../src/providers/google-antigravity/quota.js";
 
 describe("model resolution", () => {
 	it("maps Gemini variants to the shared Gemini quota pool", () => {
@@ -116,9 +117,68 @@ describe("model resolution", () => {
 		assert.equal(p.cachingStoragePer1MPerHour, 1.00);
 	});
 
+	it("uses the official Gemini 3.7 Flash introductory pricing", () => {
+		assert.deepEqual(MODEL_PRICING["gemini-3.7-flash-tiered"], {
+			inputPer1M: 0.75,
+			outputPer1M: 3.75,
+			cachingPer1M: 0.075,
+			cachingStoragePer1MPerHour: 0.5,
+		});
+	});
+
 	it("keeps quota model keys unique", () => {
 		const keys = Object.values(QUOTA_MODEL_KEYS).map((entry) => entry.key);
 		assert.equal(new Set(keys).size, keys.length);
+	});
+
+	it("resolves gemini-3.7-flash-tiered to the shared gemini quota pool", () => {
+		assert.equal(resolveQuotaModelKey("gemini-3.7-flash-tiered"), "gemini");
+		assert.equal(resolveQuotaModelKey("google/gemini-3.7-flash-tiered"), "gemini");
+	});
+
+	it("keeps gemini-3.7-flash-tiered as its exact display key", () => {
+		assert.equal(
+			resolveDisplayModelKey("gemini-3.7-flash-tiered"),
+			"gemini-3.7-flash-tiered",
+		);
+		// Provider-prefixed requests resolve to the same canonical display key.
+		assert.equal(
+			resolveDisplayModelKey("google/gemini-3.7-flash-tiered"),
+			"gemini-3.7-flash-tiered",
+		);
+	});
+
+	it("does not treat gemini-3.7-flash low/medium/high as supported virtual models", () => {
+		for (const variant of ["low", "medium", "high"]) {
+			const id = `gemini-3.7-flash-${variant}`;
+			// Falls back to the generic Flash display key, never a 3.7 virtual key.
+			assert.equal(resolveDisplayModelKey(id), "gemini-3-flash");
+			// No quota alt-key or alias entry is created for the virtual variant.
+			assert.ok(!QUOTA_MODEL_KEYS.gemini.altKeys.includes(id));
+		}
+	});
+
+	it("appends gemini-3.7-flash-tiered exactly once to the gemini quota altKeys", () => {
+		const altKeys = QUOTA_MODEL_KEYS.gemini.altKeys;
+		const matches = altKeys.filter((k) => k === "gemini-3.7-flash-tiered");
+		assert.equal(matches.length, 1);
+	});
+
+	it("extracts gemini pool quota via the gemini-3.7-flash-tiered alt key", () => {
+		const data = {
+			models: {
+				"gemini-3.7-flash-tiered": {
+					quotaInfo: { remainingFraction: 0.42 },
+				},
+			},
+		};
+		const quotas = extractQuotas(data, []);
+		const gemini = quotas.find((q) => q.modelKey === "gemini");
+		assert.ok(gemini, "alt-key extraction should surface the shared gemini pool");
+		assert.equal(gemini.displayName, "Gemini");
+		assert.equal(gemini.percentRemaining, 42);
+		// No other pool key present in the stub response.
+		assert.equal(quotas.length, 1);
 	});
 
 it("orders quota model keys: claude, gemini", () => {

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -901,6 +901,65 @@ describe("proxy e2e: 5xx (non-503)", () => {
 	});
 });
 
+describe("proxy e2e: native Gemini thinkingLevel passthrough", () => {
+	it("forwards generationConfig.thinkingConfig.thinkingLevel unchanged to upstream", async () => {
+		const captures: Capture[] = [];
+		const upstream = await listen((req, res) => {
+			let body = "";
+			req.on("data", (chunk) => { body += chunk.toString(); });
+			req.on("end", () => {
+				captures.push({ url: req.url || "", headers: req.headers, body });
+				res.writeHead(200, { "Content-Type": "text/event-stream" });
+				res.end('data: {"response":{"candidates":[{"content":{"parts":[{"text":"tiered ok"}]}}]}}\n\n');
+			});
+		});
+		endpointOverrides.splice(0, endpointOverrides.length, upstream.url);
+
+		const proxy = startProxy(makeRotator(makeAccount("tiered@example.com")), 0, "127.0.0.1");
+		await once(proxy, "listening");
+		const address = proxy.address();
+		if (!address || typeof address === "string") throw new Error("proxy did not bind");
+
+		try {
+			const response = await fetch(`http://127.0.0.1:${address.port}/v1internal:streamGenerateContent?alt=sse`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					project: "test-project",
+					model: "gemini-3.7-flash-tiered",
+					request: {
+						contents: [{ role: "user", parts: [{ text: "hello" }] }],
+						generationConfig: {
+							maxOutputTokens: 512,
+							thinkingConfig: { includeThoughts: true, thinkingLevel: "HIGH" },
+						},
+					},
+				}),
+			});
+
+			assert.equal(response.status, 200);
+			assert.match(await response.text(), /tiered ok/);
+
+			const forwarded = JSON.parse(captures[0].body) as {
+				model: string;
+				request: {
+					generationConfig: {
+						thinkingConfig?: { thinkingLevel?: string; includeThoughts?: boolean };
+					};
+				};
+			};
+			assert.equal(forwarded.model, "gemini-3.7-flash-tiered");
+			assert.deepEqual(forwarded.request.generationConfig.thinkingConfig, {
+				includeThoughts: true,
+				thinkingLevel: "HIGH",
+			});
+		} finally {
+			await new Promise<void>((resolve, reject) => proxy.close((err) => (err ? reject(err) : resolve())));
+			await upstream.close();
+		}
+	});
+});
+
 describe("proxy e2e: endpoint cascade", () => {
 	it("falls back from daily to prod endpoint when daily returns 404", async () => {
 		const dailyHits: Capture[] = [];

--- a/test/responses-compat.test.ts
+++ b/test/responses-compat.test.ts
@@ -342,6 +342,79 @@ describe("responses compat", () => {
 		}
 	});
 
+	it("maps Responses reasoning.effort to tiered thinkingLevel upstream", async () => {
+		const captures: Capture[] = [];
+		const upstream = await listenServer((req, res) => {
+			let body = "";
+			req.on("data", (chunk) => { body += chunk.toString(); });
+			req.on("end", () => {
+				captures.push({ url: req.url || "", headers: req.headers, body });
+				res.writeHead(200, { "Content-Type": "text/event-stream" });
+				res.end('data: {"response":{"candidates":[{"content":{"parts":[{"text":"pong"}]}}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}}\n\n');
+			});
+		});
+		endpointOverrides.splice(0, endpointOverrides.length, upstream.url);
+
+		try {
+			const rotator = createRotatorStub(createAccount());
+			const req = requestStream("POST", "/v1/responses", {
+				model: "gemini-3.7-flash-tiered",
+				input: "ping",
+				reasoning: { effort: "medium" },
+			});
+			const res = responseStub();
+			await handleOpenAIResponsesCreate(req, res, rotator);
+			assert.equal(res.statusCodeCaptured, 200);
+
+			const payload = JSON.parse(res.body) as { reasoning: { effort: string | null } };
+			assert.equal(payload.reasoning.effort, "medium");
+
+			const upstreamBody = JSON.parse(captures[0].body) as {
+				request: { generationConfig: { thinkingConfig?: Record<string, unknown> } };
+			};
+			assert.deepEqual(upstreamBody.request.generationConfig.thinkingConfig, {
+				includeThoughts: true,
+				thinkingLevel: "MEDIUM",
+			});
+		} finally {
+			await closeServer(upstream.server);
+		}
+	});
+
+	it("keeps tiered Responses requests adaptive when reasoning.effort is absent", async () => {
+		const captures: Capture[] = [];
+		const upstream = await listenServer((req, res) => {
+			let body = "";
+			req.on("data", (chunk) => { body += chunk.toString(); });
+			req.on("end", () => {
+				captures.push({ url: req.url || "", headers: req.headers, body });
+				res.writeHead(200, { "Content-Type": "text/event-stream" });
+				res.end('data: {"response":{"candidates":[{"content":{"parts":[{"text":"pong"}]}}]}}\n\n');
+			});
+		});
+		endpointOverrides.splice(0, endpointOverrides.length, upstream.url);
+
+		try {
+			const rotator = createRotatorStub(createAccount());
+			const req = requestStream("POST", "/v1/responses", {
+				model: "gemini-3.7-flash-tiered",
+				input: "ping",
+			});
+			const res = responseStub();
+			await handleOpenAIResponsesCreate(req, res, rotator);
+			assert.equal(res.statusCodeCaptured, 200);
+
+			const upstreamBody = JSON.parse(captures[0].body) as {
+				request: { generationConfig: { thinkingConfig?: Record<string, unknown> } };
+			};
+			assert.deepEqual(upstreamBody.request.generationConfig.thinkingConfig, {
+				includeThoughts: true,
+			});
+		} finally {
+			await closeServer(upstream.server);
+		}
+	});
+
 	it("streams Responses SSE events and keeps cancel coherent", async () => {
 		const upstream = await listenServer((req, res) => {
 			req.resume();

--- a/test/spend-logger.test.ts
+++ b/test/spend-logger.test.ts
@@ -14,6 +14,26 @@ test("calculateCost uses the official Codex GPT-5.6 rates", () => {
 	assert.equal(calculateCost("gpt-5.6-luna", 1_000_000, 1_000_000), 1.4);
 });
 
+test("calculateCost uses the official Gemini 3.7 Flash tiered rates", () => {
+	// 1M input (0.75) + 1M output (3.75) = 4.50
+	assert.equal(
+		calculateCost("gemini-3.7-flash-tiered", 1_000_000, 1_000_000),
+		4.5,
+	);
+	// Provider-prefixed ids resolve through the 3.7-flash fallback.
+	assert.equal(
+		calculateCost("google/gemini-3.7-flash-tiered", 1_000_000, 1_000_000),
+		4.5,
+	);
+});
+
+test("calculateCost never falls 3.7-flash through to gemini-3-flash rates", () => {
+	const tiered = calculateCost("gemini-3.7-flash-tiered", 1_000_000, 1_000_000);
+	const legacy = calculateCost("gemini-3-flash", 1_000_000, 1_000_000);
+	assert.equal(legacy, 3.5); // 0.50 + 3.00
+	assert.notEqual(tiered, legacy);
+});
+
 test("generateRequestId produces unique prefixed strings", () => {
   const id1 = generateRequestId();
   const id2 = generateRequestId();

--- a/test/telemetry-receiver.test.ts
+++ b/test/telemetry-receiver.test.ts
@@ -182,6 +182,45 @@ describe("telemetry receiver", () => {
 		assert.equal(stats.savings.byModel["gemini-3.6-flash"].totalUsd, 9.00);
 	});
 
+	it("calculates estimated savings for gemini 3.7 flash tiered in /v1/stats", async () => {
+		const payload = {
+			event: "heartbeat",
+			installId: "gemini37-savings-test-install",
+			version: "3.1.0",
+			nodeVersion: process.version,
+			os: process.platform,
+			arch: process.arch,
+			ts: new Date().toISOString(),
+			accountCount: 1,
+			modelsUsed: ["gemini-3.7-flash-tiered"],
+			totalRequests: 10,
+			uptimeSeconds: 300,
+			routingHealthState: "healthy",
+			tokensByModel: {
+				"gemini-3.7-flash-tiered": { input: 1_000_000, output: 1_000_000, requests: 10 },
+				"google/gemini-3.7-flash-tiered": { input: 1_000_000, output: 1_000_000, requests: 5 },
+			},
+		};
+
+		const postRes = await fetch(`http://127.0.0.1:${port}/v1/events`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(payload),
+		});
+		assert.equal(postRes.status, 202);
+
+		const statsRes = await fetch(`http://127.0.0.1:${port}/v1/stats`, {
+			headers: { Authorization: "Bearer secret-token" },
+		});
+		assert.equal(statsRes.status, 200);
+		const stats = (await statsRes.json()) as any;
+		assert.ok(stats.savings);
+		// Exact entry: 0.75 + 3.75 = 4.50 — not the gemini-3-flash 3.50 rates.
+		assert.equal(stats.savings.byModel["gemini-3.7-flash-tiered"].totalUsd, 4.50);
+		// Provider-prefixed id resolves through the 3.7-flash fallback.
+		assert.equal(stats.savings.byModel["google/gemini-3.7-flash-tiered"].totalUsd, 4.50);
+	});
+
 	it("calculates estimated savings for Ollama Cloud models in /v1/stats", async () => {
 		const payload = {
 			event: "heartbeat",

--- a/tools/telemetry-receiver/receiver.js
+++ b/tools/telemetry-receiver/receiver.js
@@ -337,6 +337,10 @@ const MODEL_PRICING = {
 	"gemini-3.6-flash-medium":  { inputPer1M: 1.50,  outputPer1M: 7.50 },
 	"gemini-3.6-flash-low":     { inputPer1M: 1.50,  outputPer1M: 7.50 },
 	"gemini-3.6-flash-tiered":  { inputPer1M: 1.50,  outputPer1M: 7.50 },
+	// Gemini 3.7 Flash tiered — public Gemini API pricing, verified
+	// 2026-08-13. Introductory rates through 2026-12-31; from 2027-01-01
+	// these double to input 1.50 / output 7.50 per 1M tokens.
+	"gemini-3.7-flash-tiered":  { inputPer1M: 0.75,  outputPer1M: 3.75 },
 	"gpt-oss-120b-medium":      { inputPer1M: 2.00,  outputPer1M: 10.00 },
 
 	// Ollama Cloud models — mirrors MODEL_PRICING in src/types.ts
@@ -374,6 +378,7 @@ function getModelPricing(model) {
 	const lower = (model || "").toLowerCase();
 	if (lower.includes("opus")) return MODEL_PRICING["claude-opus-4-6-thinking"];
 	if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
+	if (lower.includes("3.7-flash")) return MODEL_PRICING["gemini-3.7-flash-tiered"];
 	if (lower.includes("3.6-flash")) return MODEL_PRICING["gemini-3.6-flash-high"];
 	if (lower.includes("3.5-flash")) return MODEL_PRICING["gemini-3.5-flash-high"];
 	if (lower.includes("flash")) return MODEL_PRICING["gemini-3-flash"];


### PR DESCRIPTION
## Summary

- Adds `gemini-3.7-flash-tiered`, the only Gemini 3.7 model ID currently exposed by Antigravity.
- Supports Low, Medium, and High reasoning on that same model.
- Updates model discovery, quota tracking, pricing estimates, dashboard support, and regression tests.

## Tiered reasoning

Antigravity does not expose separate `-low`, `-medium`, or `-high` model IDs. Those IDs return 404.

Use the same model with:
- OpenAI API: `reasoning_effort: low | medium | high`
- Gemini API: `thinkingConfig.thinkingLevel: LOW | MEDIUM | HIGH`

When no effort is supplied, the model keeps its adaptive default.

## Manual reasoning test

The same 12-coin counterfeit puzzle was tested at each level:

| Effort | HTTP | Latency | Reasoning tokens | Answer tokens |
|---|---:|---:|---:|---:|
| Low | 200 | 3.3s | 0 | 1,577 |
| Medium | 200 | 7.3s | 1,843 | 1,316 |
| High | 200 | 10.0s | 3,939 | 153 |

Higher reasoning levels used more reasoning tokens and more time. Reasoning tokens share the model output limit, so High left fewer tokens for the visible answer.

## Checks

- 566 tests passed
- Type checks and lint passed
- Coverage thresholds passed