### PR TITLE
fix(rotator): improve 429 quota resilience, token refresh isolation, and concurrency safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ DEVELOPMENT_NOTES.md
 *.orig
 .DS_Store
 ollama-debug-last.json
+.codegraph/

--- a/src/providers/google-antigravity/index.ts
+++ b/src/providers/google-antigravity/index.ts
@@ -51,6 +51,11 @@ async function ensureGoogleToken(account: AccountRuntime): Promise<void> {
       `Account ${account.config.email} has no refreshToken; re-run login`,
     );
   }
+  if (account.config.refreshToken.startsWith("enc:")) {
+    throw new Error(
+      `Account ${account.config.email} has an encrypted refreshToken (enc:*) but it could not be decrypted. Set TUXEVIL_ROTATOR_ENCRYPTION_KEY or re-run login.`,
+    );
+  }
   const oauth = getOAuthClientConfig();
   const response = await fetchWithRetry(TOKEN_URL, {
     method: "POST",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1139,17 +1139,6 @@ export async function withRotation<T>(
     };
   };
 
-  const rotateAndRelease = async (): Promise<AccountRuntime | null> => {
-    const nextAccount = await rotator.rotateToNext(model);
-    if (nextAccount) {
-      rotator.finishRequest(
-        nextAccount,
-        routingModelKey(rotator, model),
-      );
-    }
-    return nextAccount;
-  };
-
   const maxRetries = getStreamRecoveryMaxRetries(rotator);
   const maxAttempts = maxRetries + 1;
 
@@ -1164,6 +1153,17 @@ export async function withRotation<T>(
     const displayModelKey = resolveDisplayModelKey(body.displayModel || model);
     const requestId = `${modelKey}-${Date.now().toString(36)}-${attempt + 1}`;
     const requestStartMs = Date.now();
+    let accountReleased = false;
+    const releaseCurrentAccount = (): void => {
+      if (accountReleased) return;
+      accountReleased = true;
+      rotator.finishRequest(account, modelKey);
+    };
+    const rotateAndRelease = async (): Promise<AccountRuntime | null> => {
+      releaseCurrentAccount();
+      const nextAccount = await rotator.rotateToNext(model, account);
+      return nextAccount;
+    };
     const logRequestEnd = (status: string | number, extra = ""): void => {
       log(
         `[${requestId}] END account=${label} model=${model} status=${status}${extra ? ` ${extra}` : ""} totalMs=${Date.now() - requestStartMs}`,
@@ -1258,7 +1258,7 @@ export async function withRotation<T>(
       const shouldRotate = rotator.recordRequest(account, model);
       logRequestEnd(response.status, `endpoint=${endpoint}`);
       if (shouldRotate) {
-        await rotateAndRelease();
+        await rotator.rotateToNext(model, account);
       }
       return { ok: true, result, endpoint, context };
     } catch (err) {
@@ -1317,7 +1317,7 @@ export async function withRotation<T>(
       }
       continue;
     } finally {
-      rotator.finishRequest(account, routingModelKey(rotator, model));
+      releaseCurrentAccount();
     }
   }
 
@@ -1477,16 +1477,6 @@ async function handleProxyRequest(
       }),
     );
   };
-  const rotateAndRelease = async (): Promise<AccountRuntime | null> => {
-    const nextAccount = await rotator.rotateToNext(body.model);
-    if (nextAccount) {
-      rotator.finishRequest(
-        nextAccount,
-        routingModelKey(rotator, body.model),
-      );
-    }
-    return nextAccount;
-  };
   const sendFailureDecision = (decision: UpstreamFailureDecision): void => {
     if (decision.noReplacementReason) {
       sendNoAccountsAvailable(decision.noReplacementReason);
@@ -1564,6 +1554,20 @@ async function handleProxyRequest(
     const modelKey = rotator.resolveQuotaModelKeyForDisplay(body.model) ?? body.model; // quota routing
     const displayModelKey = resolveDisplayModelKey(body.model); // metrics/logs
     const requestId = `${modelKey}-${Date.now().toString(36)}-${attempt + 1}`;
+    let accountReleased = false;
+    const releaseCurrentAccount = (): void => {
+      if (accountReleased) return;
+      accountReleased = true;
+      rotator.finishRequest(
+        account,
+        routingModelKey(rotator, body.model),
+      );
+    };
+    const rotateAndRelease = async (): Promise<AccountRuntime | null> => {
+      releaseCurrentAccount();
+      const nextAccount = await rotator.rotateToNext(body.model, account);
+      return nextAccount;
+    };
     proxyLog(
       `[${requestId}] START account=${label} model=${body.model} attempt=${attempt + 1}`,
     );
@@ -1746,7 +1750,7 @@ async function handleProxyRequest(
       res.end();
 
       if (shouldRotate) {
-        await rotateAndRelease();
+        await rotator.rotateToNext(body.model, account);
       }
       return;
     } catch (err) {
@@ -1781,10 +1785,7 @@ async function handleProxyRequest(
       }
       continue;
     } finally {
-      rotator.finishRequest(
-        account,
-        routingModelKey(rotator, body.model),
-      );
+      releaseCurrentAccount();
       if (onComplete) onComplete();
     }
   }
@@ -1850,6 +1851,16 @@ async function handleCodeAssistPassthrough(
       return;
     }
 
+    let accountReleased = false;
+    const releaseCurrentAccount = (): void => {
+      if (accountReleased) return;
+      accountReleased = true;
+      rotator.finishRequest(
+        account,
+        resolveQuotaModelKey(CODE_ASSIST_ROUTING_MODEL) ?? undefined,
+      );
+    };
+
     try {
       // getActiveAccount performs the normal account lifecycle check, but the
       // explicit provider call is required for dual Google+Ollama accounts.
@@ -1873,22 +1884,16 @@ async function handleCodeAssistPassthrough(
         res.end(JSON.stringify({ error: "Code Assist upstream request failed" }));
         return;
       }
-      const nextAccount = await rotator.rotateToNext(CODE_ASSIST_ROUTING_MODEL);
+      releaseCurrentAccount();
+      const nextAccount = await rotator.rotateToNext(CODE_ASSIST_ROUTING_MODEL, account);
       if (nextAccount) {
-        rotator.finishRequest(
-          nextAccount,
-          resolveQuotaModelKey(CODE_ASSIST_ROUTING_MODEL) ?? undefined,
-        );
         continue;
       }
       res.writeHead(503, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "No replacement Google account available" }));
       return;
     } finally {
-      rotator.finishRequest(
-        account,
-        resolveQuotaModelKey(CODE_ASSIST_ROUTING_MODEL) ?? undefined,
-      );
+      releaseCurrentAccount();
     }
   }
 }

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -1,5 +1,4 @@
-// Account rotation and token management with per-model routing
-
+import { createHash } from "node:crypto";
 import {
   type AccountConfig,
   type AccountRuntime,
@@ -10,6 +9,7 @@ import {
   type ModelQuota,
   type ModelRotationState,
   type PersistedState,
+  type ProviderCredential,
   type RoutingAccountDiagnostic,
   type RoutingModelDiagnostics,
   type RoutingRejectionReason,
@@ -42,6 +42,7 @@ import {
   saveAccountsConfig,
   removeAccountFromConfig,
   mergeCredentials,
+  normalizeAccountConfig,
 } from "./account-store.js";
 import { isHostedOAuthConfigured } from "./providers/google-antigravity/oauth.js";
 import type { RequestBody } from "./proxy.js";
@@ -82,6 +83,125 @@ import {
   setCachedTokenUsage,
 } from "./db-store.js";
 
+function credentialFingerprint(secret?: string): string {
+  if (!secret) return "";
+  return createHash("sha256").update(secret).digest("hex").slice(0, 12);
+}
+
+export function getProviderCredentialDetails(
+  norm: AccountConfig,
+  cred?: ProviderCredential,
+): {
+  provider: string;
+  projectId: string;
+  providerAccountId: string;
+  secret: string;
+  fingerprint: string;
+} {
+  const provider = cred?.provider ?? DEFAULT_PROVIDER;
+  let projectId = cred?.projectId || "";
+  let providerAccountId = cred?.providerAccountId || "";
+  let secret = cred?.refreshToken || cred?.apiKey || "";
+
+  if (provider === "google-antigravity") {
+    projectId ||= norm.projectId || "";
+    secret ||= norm.refreshToken || norm.apiKey || "";
+  } else if (provider === "openai-codex") {
+    providerAccountId ||= norm.codexAccountId || "";
+    secret ||= norm.codexRefreshToken || "";
+  }
+
+  const fingerprint = !projectId && !providerAccountId && secret ? credentialFingerprint(secret) : "";
+  return { provider, projectId, providerAccountId, secret, fingerprint };
+}
+
+export function getAccountIdentity(account: AccountConfig | AccountRuntime): string {
+  const config = "config" in account ? account.config : account;
+  const norm = normalizeAccountConfig(config);
+  const email = norm.email.toLowerCase().trim();
+  const creds = (norm.credentials ?? [])
+    .slice()
+    .sort((a, b) => a.provider.localeCompare(b.provider))
+    .map((c) => {
+      const details = getProviderCredentialDetails(norm, c);
+      return `${details.provider}:${details.projectId}:${details.providerAccountId}:${details.fingerprint}`;
+    })
+    .join("|");
+  if (!creds) {
+    const details = getProviderCredentialDetails(norm, { provider: DEFAULT_PROVIDER });
+    return `${email}#${details.provider}:${details.projectId}:${details.providerAccountId}:${details.fingerprint}`;
+  }
+  return `${email}#${creds}`;
+}
+
+export function areAccountIdentitiesCompatible(
+  incomingConfig: AccountConfig,
+  existingConfig: AccountConfig,
+): boolean {
+  const normInc = normalizeAccountConfig(incomingConfig);
+  const normExt = normalizeAccountConfig(existingConfig);
+  if (normInc.email.toLowerCase().trim() !== normExt.email.toLowerCase().trim()) {
+    return false;
+  }
+
+  const incCreds = normInc.credentials ?? [];
+  const extCreds = normExt.credentials ?? [];
+
+  let hadOverlap = false;
+  for (const inc of incCreds) {
+    const ext = extCreds.find((c) => c.provider === inc.provider);
+    if (ext) {
+      hadOverlap = true;
+      const incDetails = getProviderCredentialDetails(normInc, inc);
+      const extDetails = getProviderCredentialDetails(normExt, ext);
+
+      if (incDetails.projectId && extDetails.projectId && incDetails.projectId !== extDetails.projectId) {
+        return false;
+      }
+      if (incDetails.providerAccountId && extDetails.providerAccountId && incDetails.providerAccountId !== extDetails.providerAccountId) {
+        return false;
+      }
+      if (!incDetails.projectId && !extDetails.projectId && !incDetails.providerAccountId && !extDetails.providerAccountId) {
+        if (incDetails.secret && extDetails.secret && incDetails.secret !== extDetails.secret) {
+          return false;
+        }
+      }
+    }
+  }
+
+  if (hadOverlap) {
+    return true;
+  }
+
+  const incDef = getProviderCredentialDetails(normInc, { provider: DEFAULT_PROVIDER });
+  const extDef = getProviderCredentialDetails(normExt, { provider: DEFAULT_PROVIDER });
+  if (incDef.projectId && extDef.projectId && incDef.projectId !== extDef.projectId) {
+    return false;
+  }
+  if (incDef.providerAccountId && extDef.providerAccountId && incDef.providerAccountId !== extDef.providerAccountId) {
+    return false;
+  }
+  if (!incDef.projectId && !extDef.projectId && !incDef.providerAccountId && !extDef.providerAccountId) {
+    if (incDef.secret && extDef.secret && incDef.secret !== extDef.secret) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function getCredentialGeneration(
+  account: AccountRuntime | AccountConfig,
+  providerId: string,
+): string {
+  const config = "config" in account ? account.config : account;
+  const norm = normalizeAccountConfig(config);
+  const cred = norm.credentials?.find((c) => c.provider === providerId);
+  const details = getProviderCredentialDetails(norm, cred ?? { provider: providerId });
+  if (!cred && !details.secret) return "none";
+  return `${providerId}:${details.projectId}:${details.providerAccountId}:${details.secret}`;
+}
+
 const rotatorLogger = logger.child("rotator");
 
 function currentUtcDay(now = Date.now()): string {
@@ -115,6 +235,8 @@ export class AccountRotator {
   private defaultIndex = 0;
   private startTime = Date.now();
   private quotaPollTimer: ReturnType<typeof setInterval> | null = null;
+  private quotaInitialPollTimer: ReturnType<typeof setTimeout> | null = null;
+  private inFlightRefreshes = new WeakMap<AccountRuntime, Map<string, Promise<void>>>();
   private protectivePauseUntil = 0;
   private protectivePauseReason: string | null = null;
   private allowFreshWindowStarts = true;
@@ -613,12 +735,16 @@ export class AccountRotator {
     this.log(`Quota polling every ${Math.round(intervalMs / 1000)}s`);
 
     // Initial poll (delayed 2s to allow token refresh first)
-    setTimeout(() => this.pollAllQuotas(), 2000);
+    this.quotaInitialPollTimer = setTimeout(() => this.pollAllQuotas(), 2000);
 
     this.quotaPollTimer = setInterval(() => this.pollAllQuotas(), intervalMs);
   }
 
   stopQuotaPolling(): void {
+    if (this.quotaInitialPollTimer) {
+      clearTimeout(this.quotaInitialPollTimer);
+      this.quotaInitialPollTimer = null;
+    }
     if (this.quotaPollTimer) {
       clearInterval(this.quotaPollTimer);
       this.quotaPollTimer = null;
@@ -1000,7 +1126,7 @@ export class AccountRotator {
     return best;
   }
 
-  private countModelAssignment(modelKey: string): void {
+  countModelAssignment(modelKey: string): void {
     const state = this.modelState.get(modelKey);
     if (state) {
       state.requestsOnActiveAccount++;
@@ -1025,11 +1151,7 @@ export class AccountRotator {
     now: number = Date.now(),
     excludeIdx?: number,
   ): Promise<AccountRuntime | null> {
-    const account = await this.rotateModel(modelKey, now, excludeIdx);
-    if (account) {
-      this.countModelAssignment(modelKey);
-    }
-    return account;
+    return this.rotateModel(modelKey, now, excludeIdx, true);
   }
 
   private rollDailySafetyIfNeeded(now: number): void {
@@ -1655,11 +1777,18 @@ export class AccountRotator {
         }
       }
       this.startRequest(current, modelKey ?? undefined);
+      if (modelKey && state) {
+        state.requestsOnActiveAccount++;
+        this.scheduleStateSave();
+      }
       try {
         await this.ensureValidTokenForModel(current, modelKey);
-        if (modelKey) this.countModelAssignment(modelKey);
         return current;
       } catch (err) {
+        if (modelKey && state) {
+          state.requestsOnActiveAccount = Math.max(0, state.requestsOnActiveAccount - 1);
+          this.scheduleStateSave();
+        }
         this.refundTokenBucket(current, Date.now());
         this.finishRequest(current, modelKey ?? undefined);
         if (modelKey && this.isCodexPoolKey(modelKey)) {
@@ -1673,7 +1802,8 @@ export class AccountRotator {
     if (modelKey) {
       return this.rotateModelForRequest(modelKey, now, state ? idx : -1);
     }
-    return this.rotateDefault();
+    const defaultAcc = await this.rotateDefault(now, true);
+    return defaultAcc;
   }
 
   private async restorePreferredModelAccount(
@@ -1710,8 +1840,8 @@ export class AccountRotator {
       modelKey,
       preferred,
       preferredIndex,
+      true,
     );
-    this.countModelAssignment(modelKey);
     return restored;
   }
 
@@ -1721,6 +1851,7 @@ export class AccountRotator {
     now: number = Date.now(),
     excludeIdx: number = this.modelState.get(modelKey)?.activeAccountIndex ??
       -1,
+    forRequest = false,
   ): Promise<AccountRuntime | null> {
     const best = this.pickBestModelAccount(modelKey, now, excludeIdx);
 
@@ -1751,13 +1882,23 @@ export class AccountRotator {
         `[${modelKey}] Rotated to ${best.config.label || best.config.email} [${timerType}] (quota: ${quota >= 0 ? quota + "%" : "unknown"})`,
       );
       try {
-        return await this.activateModelAccount(modelKey, best, stickyAccountIndex);
+        return await this.activateModelAccount(
+          modelKey,
+          best,
+          stickyAccountIndex,
+          forRequest,
+        );
       } catch (error) {
         if (!this.isCodexPoolKey(modelKey)) throw error;
         // A bad Codex refresh token is provider-scoped. The failed account is
         // marked invalid by ensureValidTokenForProvider, so retry selection
         // with the next Codex account without touching Google/Ollama pools.
-        return this.rotateModel(modelKey, now, this.accounts.indexOf(best));
+        return this.rotateModel(
+          modelKey,
+          now,
+          this.accounts.indexOf(best),
+          forRequest,
+        );
       }
     }
 
@@ -1809,25 +1950,34 @@ export class AccountRotator {
     modelKey: string,
     account: AccountRuntime,
     stickyAccountIndex?: number,
+    forRequest = false,
   ): Promise<AccountRuntime> {
+    if (forRequest) {
+      this.startRequest(account, modelKey);
+    }
     const newIdx = this.accounts.indexOf(account);
     const quota = this.getModelQuota(account, modelKey);
-    this.modelState.set(modelKey, {
+    const state: ModelRotationState = {
       activeAccountIndex: newIdx,
       stickyAccountIndex: this.isQuotaAwarePolicy()
         ? stickyAccountIndex ?? newIdx
         : undefined,
       quotaAtRotationStart: quota,
-      requestsOnActiveAccount: 0,
-    });
-    await this.saveState();
-    this.startRequest(account, modelKey);
+      requestsOnActiveAccount: forRequest ? 1 : 0,
+    };
+    this.modelState.set(modelKey, state);
     try {
+      await this.saveState();
       await this.ensureValidTokenForModel(account, modelKey);
       return account;
     } catch (err) {
-      this.refundTokenBucket(account, Date.now());
-      this.finishRequest(account, modelKey);
+      if (forRequest) {
+        if (this.modelState.get(modelKey) === state) {
+          state.requestsOnActiveAccount = Math.max(0, state.requestsOnActiveAccount - 1);
+        }
+        this.refundTokenBucket(account, Date.now());
+        this.finishRequest(account, modelKey);
+      }
       throw err;
     }
   }
@@ -1835,11 +1985,13 @@ export class AccountRotator {
   // Fallback rotation when model can't be resolved
   private async rotateDefault(
     now: number = Date.now(),
+    forRequest = false,
+    excludeIdx = this.defaultIndex,
   ): Promise<AccountRuntime | null> {
     let best: AccountRuntime | null = null;
 
     for (let i = 0; i < this.accounts.length; i++) {
-      if (i === this.defaultIndex) continue;
+      if (i === excludeIdx) continue;
       const account = this.accounts[i];
       if (this.isAvailable(account, now)) {
         best = account;
@@ -1848,18 +2000,22 @@ export class AccountRotator {
     }
 
     if (best) {
+      if (forRequest) {
+        this.startRequest(best);
+      }
       this.defaultIndex = this.accounts.indexOf(best);
       this.log(
         `[default] Rotated to ${best.config.label || best.config.email}`,
       );
-      await this.saveState();
-      this.startRequest(best);
       try {
+        await this.saveState();
         await this.ensureValidToken(best);
         return best;
       } catch (err) {
-        this.refundTokenBucket(best, Date.now());
-        this.finishRequest(best);
+        if (forRequest) {
+          this.refundTokenBucket(best, Date.now());
+          this.finishRequest(best);
+        }
         throw err;
       }
     }
@@ -1888,10 +2044,31 @@ export class AccountRotator {
   }
 
   // Force rotation for a model (called from proxy on 429 etc.)
-  async rotateToNext(model?: string): Promise<AccountRuntime | null> {
+  async rotateToNext(
+    model?: string,
+    failedAccount?: AccountRuntime | number | string,
+  ): Promise<AccountRuntime | null> {
     if (this.isProtectivePauseActive(Date.now())) return null;
     const modelKey = model ? this.resolvePoolKeyForModel(model) : null;
-    return modelKey ? this.rotateModel(modelKey) : this.rotateDefault();
+    let excludeIdx: number;
+    if (typeof failedAccount === "number") {
+      excludeIdx = failedAccount;
+    } else if (typeof failedAccount === "string") {
+      excludeIdx = this.accounts.findIndex(
+        (a) =>
+          getAccountIdentity(a.config) === failedAccount ||
+          a.config.email.toLowerCase() === failedAccount.toLowerCase(),
+      );
+    } else if (failedAccount && typeof failedAccount === "object") {
+      excludeIdx = this.accounts.indexOf(failedAccount);
+    } else {
+      excludeIdx = modelKey
+        ? this.modelState.get(modelKey)?.activeAccountIndex ?? -1
+        : this.defaultIndex;
+    }
+    return modelKey
+      ? this.rotateModel(modelKey, Date.now(), excludeIdx)
+      : this.rotateDefault(Date.now(), false, excludeIdx);
   }
 
   // Record a successful request. Returns true if rotation is needed.
@@ -2732,10 +2909,10 @@ export class AccountRotator {
     }
     const adapter = getProviderForAccount(account.config);
     try {
-      await adapter.ensureValidToken(account);
+      await this.ensureValidTokenForProvider(account, adapter.id);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (msg.startsWith("Token refresh failed")) {
+      if (msg.startsWith("Token refresh failed") || msg.startsWith("Token refresh error:")) {
         this.markError(account, msg);
         throw err;
       }
@@ -2749,22 +2926,111 @@ export class AccountRotator {
     account: AccountRuntime,
     providerId: string,
   ): Promise<void> {
-    const adapter = getProviderAdapter(providerId);
-    try {
-      await adapter.ensureValidToken(account);
-    } catch (error) {
-      if (
-        providerId === "openai-codex" &&
-        (error instanceof CodexOAuthError ||
-          (typeof error === "object" && error !== null &&
-            (error as { reloginRequired?: unknown }).reloginRequired === true))
-      ) {
-        const reason = error instanceof Error
-          ? error.message
-          : "Codex credential requires re-authentication";
-        this.markProviderInvalid(account, providerId, reason);
+    const startGen = getCredentialGeneration(account, providerId);
+    const flightKey = `${providerId}:${startGen}`;
+
+    let providerMap = this.inFlightRefreshes.get(account);
+    if (!providerMap) {
+      providerMap = new Map();
+      this.inFlightRefreshes.set(account, providerMap);
+    }
+    const existing = providerMap.get(flightKey);
+    if (existing) {
+      await existing;
+      const currentGen = getCredentialGeneration(account, providerId);
+      if (currentGen === startGen) {
+        return;
       }
-      throw error;
+      return this.ensureValidTokenForProvider(account, providerId);
+    }
+
+    const refreshPromise = (async () => {
+      const adapter = getProviderAdapter(providerId);
+      const snapshotAccount: AccountRuntime = {
+        ...account,
+        config: {
+          ...account.config,
+          credentials: (account.config.credentials ?? []).map((c) => ({ ...c })),
+        },
+        providerTokens: account.providerTokens
+          ? { ...account.providerTokens }
+          : {},
+      };
+
+      try {
+        await adapter.ensureValidToken(snapshotAccount);
+      } catch (error) {
+        const currentGen = getCredentialGeneration(account, providerId);
+        if (currentGen !== startGen) {
+          return;
+        }
+        if (
+          providerId === "openai-codex" &&
+          (error instanceof CodexOAuthError ||
+            (typeof error === "object" &&
+              error !== null &&
+              (error as { reloginRequired?: unknown }).reloginRequired === true))
+        ) {
+          const reason =
+            error instanceof Error
+              ? error.message
+              : "Codex credential requires re-authentication";
+          this.markProviderInvalid(account, providerId, reason);
+        }
+        throw error;
+      }
+
+      const currentGen = getCredentialGeneration(account, providerId);
+      if (currentGen !== startGen) {
+        return;
+      }
+
+      // Publish ONLY the state owned by providerId
+      if (providerId === "google-antigravity" || providerId === DEFAULT_PROVIDER) {
+        account.accessToken = snapshotAccount.accessToken;
+        account.tokenExpires = snapshotAccount.tokenExpires;
+        if (snapshotAccount.config.refreshToken !== undefined) {
+          account.config.refreshToken = snapshotAccount.config.refreshToken;
+        }
+      } else {
+        if (snapshotAccount.providerTokens?.[providerId]) {
+          account.providerTokens ??= {};
+          account.providerTokens[providerId] = snapshotAccount.providerTokens[providerId];
+        }
+        if (providerId === "openai-codex" && snapshotAccount.config.codexRefreshToken !== undefined) {
+          account.config.codexRefreshToken = snapshotAccount.config.codexRefreshToken;
+        }
+      }
+
+      // Update ONLY providerId's credential in account.config.credentials
+      const snapshotCred = snapshotAccount.config.credentials?.find((c) => c.provider === providerId);
+      if (snapshotCred) {
+        if (!account.config.credentials) {
+          account.config.credentials = [{ ...snapshotCred }];
+        } else {
+          const idx = account.config.credentials.findIndex((c) => c.provider === providerId);
+          if (idx >= 0) {
+            account.config.credentials[idx] = { ...account.config.credentials[idx], ...snapshotCred };
+          } else {
+            account.config.credentials.push({ ...snapshotCred });
+          }
+        }
+      }
+      account.consecutiveErrors = 0;
+    })();
+
+    providerMap.set(flightKey, refreshPromise);
+    try {
+      await refreshPromise;
+      const currentGen = getCredentialGeneration(account, providerId);
+      if (currentGen !== startGen) {
+        return this.ensureValidTokenForProvider(account, providerId);
+      }
+    } finally {
+      providerMap.delete(flightKey);
+      if (providerMap.size === 0) {
+        this.inFlightRefreshes.delete(account);
+      }
     }
   }
 
@@ -3164,22 +3430,39 @@ export class AccountRotator {
 
   async replaceConfig(nextConfig: Config): Promise<void> {
     const normalized = applyConfigDefaults(nextConfig);
-    const previous = new Map(
-      this.accounts.map((account) => [account.config.email, account]),
-    );
-    const mergedAccounts = normalized.accounts.map((config) => {
-      const existing = previous.get(config.email);
-      if (existing) {
-        const mergedConfig = {
+    const unmatchedExisting = [...this.accounts];
+    const matchAndReuseAccount = (config: AccountConfig): AccountRuntime => {
+      const targetId = getAccountIdentity(config);
+      const exactIdx = unmatchedExisting.findIndex(
+        (a) => getAccountIdentity(a.config) === targetId,
+      );
+      if (exactIdx !== -1) {
+        const [existing] = unmatchedExisting.splice(exactIdx, 1);
+        existing.config = {
           ...existing.config,
           ...config,
           credentials: mergeCredentials(existing.config.credentials, config.credentials),
         };
-        return {
-          ...existing,
-          config: mergedConfig,
-        };
+        return existing;
       }
+
+      const matchingIndices: number[] = [];
+      for (let i = 0; i < unmatchedExisting.length; i++) {
+        if (areAccountIdentitiesCompatible(config, unmatchedExisting[i].config)) {
+          matchingIndices.push(i);
+        }
+      }
+
+      if (matchingIndices.length === 1) {
+        const [existing] = unmatchedExisting.splice(matchingIndices[0], 1);
+        existing.config = {
+          ...existing.config,
+          ...config,
+          credentials: mergeCredentials(existing.config.credentials, config.credentials),
+        };
+        return existing;
+      }
+
       return {
         config,
         accessToken: null,
@@ -3212,7 +3495,9 @@ export class AccountRotator {
           lastRefillAt: Date.now(),
         },
       };
-    });
+    };
+
+    const mergedAccounts = normalized.accounts.map(matchAndReuseAccount);
     this.config = { ...normalized, accounts: mergedAccounts.map((account) => account.config) };
     this.accounts = mergedAccounts;
     await saveAccountsConfig(this.config);

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -97,7 +97,7 @@ function makeRotator(
 	return {
 		getActiveAccount: async () => accounts[activeIndex],
 		getRetryAfterMs: () => 0,
-		rotateToNext: async () => {
+		rotateToNext: async (_model?: string, _failedAccount?: AccountRuntime | number | string) => {
 			if (activeIndex >= accounts.length - 1) return null;
 			activeIndex += 1;
 			tracking.rotations!++;
@@ -475,9 +475,9 @@ describe("proxy e2e: 429 rate-limited", () => {
 			assert.equal(tracking.markExhausted, 1);
 			assert.equal(tracking.recordProvider429, 1);
 			assert.equal(tracking.rotations, 1);
-			// rotateToNext briefly starts/releases the reserved account; the next
-			// loop starts/releases it again for the actual retry.
-			assert.equal(tracking.finishRequest, 3, "failed account and reservation lifecycle must be balanced");
+			// Failed account is released on error before rotation, and retry
+			// account is released after successful completion.
+			assert.equal(tracking.finishRequest, 2, "failed account and retry request lifecycle must be balanced");
 		} finally {
 			await upstream.close();
 		}

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -1,0 +1,1175 @@
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// 1. Isolate environment BEFORE any dynamic module imports to prevent touching operator DB/files
+const savedEnv = {
+  TUXEVIL_ROTATOR_DIR: process.env.TUXEVIL_ROTATOR_DIR,
+  PI_ROTATOR_DIR: process.env.PI_ROTATOR_DIR,
+  DATABASE_URL: process.env.DATABASE_URL,
+  TUXEVIL_ROTATOR_DATABASE_URL: process.env.TUXEVIL_ROTATOR_DATABASE_URL,
+  PI_ROTATOR_DATABASE_URL: process.env.PI_ROTATOR_DATABASE_URL,
+  ANTIGRAVITY_CLIENT_ID: process.env.ANTIGRAVITY_CLIENT_ID,
+  ANTIGRAVITY_CLIENT_SECRET: process.env.ANTIGRAVITY_CLIENT_SECRET,
+};
+
+const testDir = mkdtempSync(join(tmpdir(), "rotator-429-resilience-"));
+process.env.TUXEVIL_ROTATOR_DIR = testDir;
+process.env.PI_ROTATOR_DIR = testDir;
+delete process.env.DATABASE_URL;
+delete process.env.TUXEVIL_ROTATOR_DATABASE_URL;
+delete process.env.PI_ROTATOR_DATABASE_URL;
+process.env.ANTIGRAVITY_CLIENT_ID = "test-client-id";
+process.env.ANTIGRAVITY_CLIENT_SECRET = "test-client-secret";
+
+let AccountRotator: typeof import("../src/rotator.js").AccountRotator;
+let initDb: typeof import("../src/db-store.js").initDb;
+let closeDb: typeof import("../src/db-store.js").closeDb;
+let isDbConfigured: typeof import("../src/db-store.js").isDbConfigured;
+let getAccountsPath: typeof import("../src/paths.js").getAccountsPath;
+let getProviderAdapter: typeof import("../src/providers/registry.js").getProviderAdapter;
+type AccountRuntime = import("../src/types.js").AccountRuntime;
+
+before(async () => {
+  const dbStore = await import("../src/db-store.js");
+  const rotatorMod = await import("../src/rotator.js");
+  const pathsMod = await import("../src/paths.js");
+  const regMod = await import("../src/providers/registry.js");
+
+  initDb = dbStore.initDb;
+  closeDb = dbStore.closeDb;
+  isDbConfigured = dbStore.isDbConfigured;
+  AccountRotator = rotatorMod.AccountRotator;
+  getAccountsPath = pathsMod.getAccountsPath;
+  getProviderAdapter = regMod.getProviderAdapter;
+
+  // Verify hermetic file-based isolation
+  assert.ok(
+    getAccountsPath().startsWith(testDir),
+    `Paths must point to isolated testDir (${testDir}), got ${getAccountsPath()}`,
+  );
+
+  await initDb();
+});
+
+after(async () => {
+  await closeDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort cleanup */
+  }
+
+  // Restore saved environment
+  for (const [key, val] of Object.entries(savedEnv)) {
+    if (val === undefined) delete process.env[key];
+    else process.env[key] = val;
+  }
+});
+
+function makeAccount(
+  email: string,
+  projectId = "shared-project",
+  modelKey = "claude",
+  quotaPercent = 100,
+  initialTokens = 50,
+): AccountRuntime {
+  return {
+    config: {
+      email,
+      projectId,
+      credentials: [{ provider: "google-antigravity" }],
+      label: email,
+    },
+    accessToken: `token-${email}`,
+    tokenExpires: Date.now() + 3600000,
+    requestsSinceRotation: 0,
+    totalRequests: 0,
+    cooldownsByModel: {},
+    quotaExhaustedAt: 0,
+    quota: [
+      {
+        modelKey,
+        displayName: modelKey,
+        percentRemaining: quotaPercent,
+        resetTime: null,
+        timerType: "fresh",
+        providerId: "google-antigravity",
+      } as AccountRuntime["quota"][number],
+    ],
+    lastQuotaPoll: Date.now(),
+    lastUsed: 0,
+    lastError: null,
+    consecutiveErrors: 0,
+    disabled: false,
+    flagged: false,
+    inFlightRequests: 0,
+    inFlightByModel: {},
+    allowFreshWindowStartsOverride: false,
+    dailyRequestCount: 0,
+    dailyRequestDay: "2026-08-21",
+    healthScore: 1,
+    tokenBucket: { tokens: initialTokens, lastRefillAt: Date.now() },
+  };
+}
+
+describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
+  it("hostile database environment variables do not select external database backend", () => {
+    // Assert db-store is not connected to PostgreSQL
+    assert.equal(isDbConfigured(), false, "isDbConfigured must be false when DB URL is not set");
+  });
+
+  it("rotateModel and activateModelAccount do not leak in-flight counters during background polling", async () => {
+    const acc1 = makeAccount("acc1@example.com", "shared-project", "claude", 100);
+    const acc2 = makeAccount("acc2@example.com", "shared-project", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51201,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [acc1.config, acc2.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 0,
+    });
+
+    const rotated = await rotator.rotateModel("claude");
+    assert.ok(rotated);
+    assert.equal(rotated.config.email, "acc2@example.com");
+
+    // In-flight requests and inFlightByModel must remain 0 after background/manual rotateModel
+    assert.equal(acc1.inFlightRequests, 0, "acc1 inFlightRequests must remain 0 after rotateModel");
+    assert.deepEqual(acc1.inFlightByModel, {}, "acc1 inFlightByModel must remain empty after rotateModel");
+    assert.equal(acc2.inFlightRequests, 0, "acc2 inFlightRequests must remain 0 after rotateModel");
+    assert.deepEqual(acc2.inFlightByModel, {}, "acc2 inFlightByModel must remain empty after rotateModel");
+  });
+
+  it("getActiveAccount leases account with inFlight=1, and finishRequest resets to 0", async () => {
+    const acc1 = makeAccount("active@example.com", "shared-project", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51202,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [acc1.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 0,
+    });
+
+    const account = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.ok(account);
+    assert.equal(account.inFlightRequests, 1, "inFlightRequests must be 1 while request is active");
+    assert.equal(account.inFlightByModel["claude"], 1, "inFlightByModel['claude'] must be 1");
+
+    rotator.finishRequest(account, "claude");
+    assert.equal(account.inFlightRequests, 0, "inFlightRequests must be 0 after finishRequest");
+    assert.deepEqual(account.inFlightByModel, {}, "inFlightByModel must be empty after finishRequest");
+  });
+
+  it("rotateToNext finds available replacement account when previous account in same project is released", async () => {
+    const acc1 = makeAccount("acc1@example.com", "shared-project", "claude", 100);
+    const acc2 = makeAccount("acc2@example.com", "shared-project", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51203,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [acc1.config, acc2.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 0,
+    });
+
+    // Simulate start of request on acc1
+    const initial = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.equal(initial?.config.email, "acc1@example.com");
+    assert.equal(acc1.inFlightRequests, 1);
+
+    // If acc1 encounters 429 RESOURCE_EXHAUSTED:
+    // Proxy marks it exhausted and calls finishRequest BEFORE rotateToNext
+    rotator.markExhausted(acc1, "claude", 1800000);
+    rotator.finishRequest(acc1, "claude");
+
+    // Project concurrency is now clear (0 in-flight for shared-project), so acc2 is eligible
+    const nextAccount = await rotator.rotateToNext("claude-opus-4-6-thinking", acc1);
+    assert.ok(nextAccount, "rotateToNext must find available sibling account in same project");
+    assert.equal(nextAccount.config.email, "acc2@example.com");
+
+    // Next loop attempt leases acc2
+    const retryAccount = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.equal(retryAccount?.config.email, "acc2@example.com");
+    assert.equal(acc2.inFlightRequests, 1);
+
+    // Successful completion releases acc2
+    rotator.finishRequest(retryAccount!, "claude");
+    assert.equal(acc2.inFlightRequests, 0);
+    assert.deepEqual(acc2.inFlightByModel, {});
+  });
+
+  it("replaceConfig preserves stable runtime object identity for active requests", async () => {
+    const accA = makeAccount("accA@example.com", "proj-a", "claude", 100);
+    const accB = makeAccount("accB@example.com", "proj-b", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51203,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accA.config, accB.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [accA, accB];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 0,
+    });
+
+    // Request leases accA
+    const active = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.equal(active, accA, "Leased runtime must be accA");
+
+    // Replace configuration with updated labels/settings
+    await rotator.replaceConfig({
+      proxyPort: 51203,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [
+        { ...accA.config, label: "Updated Label A" },
+        { ...accB.config, label: "Updated Label B" },
+      ],
+    });
+
+    const accountsAfter = (rotator as any).accounts as AccountRuntime[];
+    assert.equal(accountsAfter[0], accA, "replaceConfig must preserve exact runtime object identity for accA");
+    assert.equal(accountsAfter[1], accB, "replaceConfig must preserve exact runtime object identity for accB");
+    assert.equal(accountsAfter[0].config.label, "Updated Label A");
+
+    rotator.finishRequest(active!, "claude");
+  });
+
+  it("rotateToNext excludes explicitly failed account WITHOUT cooldown and across replaceConfig", async () => {
+    const accA = makeAccount("accA@example.com", "proj-a", "claude", 100);
+    const accB = makeAccount("accB@example.com", "proj-b", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51204,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [accA.config, accB.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [accA, accB];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 0,
+    });
+
+    // 1. Start request on accA
+    const active = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.equal(active, accA);
+
+    // 2. Run replaceConfig while accA is active
+    await rotator.replaceConfig({
+      proxyPort: 51204,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accA.config, accB.config],
+    });
+
+    // 3. Fail the request (transport/5xx failure: release account without markExhausted or cooldown)
+    rotator.finishRequest(active!, "claude");
+    assert.equal(accA.cooldownsByModel["claude"] ?? 0, 0, "No cooldown applied on accA");
+
+    // 4. Rotate to next specifying failedAccount = accA
+    const nextAccount = await rotator.rotateToNext("claude-opus-4-6-thinking", active!);
+    assert.ok(nextAccount);
+    assert.equal(
+      nextAccount.config.email,
+      "accB@example.com",
+      "Must select accB, never re-selecting failed account accA",
+    );
+  });
+
+  it("deterministic barrier: concurrent getActiveAccount calls reserve account before async save/refresh and enforce concurrency limit", async () => {
+    const acc1 = makeAccount("acc1@example.com", "proj-1", "claude", 0); // 0% quota forces rotation
+    const acc2 = makeAccount("acc2@example.com", "proj-2", "claude", 100);
+    const acc3 = makeAccount("acc3@example.com", "proj-3", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51205,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [acc1.config, acc2.config, acc3.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2, acc3];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 0,
+      requestsOnActiveAccount: 0,
+    });
+
+    // Deterministic barrier inside saveState during activation of Request 1
+    let barrierReached: (() => void) | null = null;
+    const reachedPromise = new Promise<void>((resolve) => {
+      barrierReached = resolve;
+    });
+    let barrierRelease: (() => void) | null = null;
+    const releasePromise = new Promise<void>((resolve) => {
+      barrierRelease = resolve;
+    });
+
+    const originalSaveState = (rotator as any).saveState.bind(rotator);
+    let intercepted = false;
+    (rotator as any).saveState = async () => {
+      if (!intercepted) {
+        intercepted = true;
+        barrierReached!();
+        await releasePromise;
+      }
+      return originalSaveState();
+    };
+
+    // 1. Launch Request 1
+    const req1Promise = rotator.getActiveAccount("claude-opus-4-6-thinking");
+
+    // 2. Wait until Request 1 has entered activation and is paused inside saveState()
+    await reachedPromise;
+
+    // At this barrier:
+    // With fix: acc2.inFlightRequests is already 1 (reserved synchronously)
+    // Without fix: acc2.inFlightRequests was 0 (leaking to req2)
+    assert.equal(acc2.inFlightRequests, 1, "acc2 must be reserved with inFlight=1 before saveState resolves");
+
+    // 3. Launch Request 2 while Request 1 is still paused at saveState barrier
+    const req2 = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.ok(req2, "Request 2 must obtain an account");
+    assert.equal(
+      req2.config.email,
+      "acc3@example.com",
+      "Request 2 must select acc3 while acc2 is leased by paused Request 1",
+    );
+    assert.equal(acc3.inFlightRequests, 1, "acc3 inFlightRequests must be 1");
+
+    // 4. Release Request 1 barrier and await completion
+    barrierRelease!();
+    const req1 = await req1Promise;
+    assert.ok(req1);
+    assert.equal(req1.config.email, "acc2@example.com");
+
+    // Assert neither account ever exceeded 1 in-flight
+    assert.equal(acc2.inFlightRequests, 1);
+    assert.equal(acc3.inFlightRequests, 1);
+
+    // Cleanup
+    rotator.finishRequest(req1, "claude");
+    rotator.finishRequest(req2, "claude");
+    assert.equal(acc2.inFlightRequests, 0);
+    assert.equal(acc3.inFlightRequests, 0);
+  });
+
+  it("refunds token bucket and reverts inFlight when model-specific activation fails before request", async () => {
+    const acc1 = makeAccount("acc1@example.com", "proj-1", "claude", 0, 1); // 0% quota, 1 token
+    const acc2 = makeAccount("acc2@example.com", "proj-2", "claude", 100, 1); // 100% quota, 1 token
+
+    const rotator = new AccountRotator({
+      proxyPort: 51206,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "hybrid",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      tokenBucketEnabled: true,
+      tokenBucketMaxTokens: 1,
+      tokenBucketInitialTokens: 1,
+      tokenBucketRefillPerMinute: 0.00001,
+      accounts: [acc1.config, acc2.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2];
+    acc2.tokenBucket = { tokens: 1, lastRefillAt: Date.now() };
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 0,
+      requestsOnActiveAccount: 0,
+    });
+
+    // Simulate token refresh failure
+    (rotator as any).ensureValidTokenForModel = async () => {
+      throw new Error("Simulated model refresh failure");
+    };
+
+    await assert.rejects(
+      async () => {
+        await rotator.getActiveAccount("claude-opus-4-6-thinking");
+      },
+      /Simulated model refresh failure/,
+    );
+
+    // Assert token was refunded (tokens=1) and inFlight=0
+    assert.equal(acc2.tokenBucket.tokens, 1, "acc2 token bucket must be refunded to 1 on activation failure");
+    assert.equal(acc2.inFlightRequests, 0, "acc2 inFlightRequests must be 0");
+    assert.deepEqual(acc2.inFlightByModel, {}, "acc2 inFlightByModel must be empty");
+  });
+
+  it("refunds token bucket and reverts inFlight when default rotation activation fails before request", async () => {
+    const acc1 = makeAccount("acc1@example.com", "proj-1", "claude", 100, 1);
+    const acc2 = makeAccount("acc2@example.com", "proj-2", "claude", 100, 1);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51207,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "hybrid",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      tokenBucketEnabled: true,
+      tokenBucketMaxTokens: 1,
+      tokenBucketInitialTokens: 1,
+      tokenBucketRefillPerMinute: 0.00001,
+      accounts: [acc1.config, acc2.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2];
+    acc2.tokenBucket = { tokens: 1, lastRefillAt: Date.now() };
+    acc1.disabled = true; // Force rotation to acc2
+
+    // Simulate token refresh failure
+    (rotator as any).ensureValidToken = async () => {
+      throw new Error("Simulated default refresh failure");
+    };
+
+    await assert.rejects(
+      async () => {
+        // No model specified triggers rotateDefault
+        await rotator.getActiveAccount();
+      },
+      /Simulated default refresh failure/,
+    );
+
+    // Assert token was refunded (tokens=1) and inFlight=0
+    assert.equal(acc2.tokenBucket.tokens, 1, "acc2 token bucket must be refunded to 1 on default rotation failure");
+    assert.equal(acc2.inFlightRequests, 0, "acc2 inFlightRequests must be 0");
+  });
+
+  it("executes at most one refresh per account and provider concurrently (single-flight)", async () => {
+    const acc = makeAccount("singleflight@example.com", "proj-sf", "claude", 100);
+    const rotator = new AccountRotator({
+      proxyPort: 51208,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc];
+
+    let adapterRefreshCalls = 0;
+    const adapter = getProviderAdapter("google-antigravity");
+    const originalEnsureValid = adapter.ensureValidToken.bind(adapter);
+    adapter.ensureValidToken = async (account: AccountRuntime) => {
+      adapterRefreshCalls++;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      account.accessToken = "refreshed-token";
+      return originalEnsureValid(account);
+    };
+
+    try {
+      // Trigger multiple concurrent ensureValidToken calls for the same account
+      await Promise.all([
+        rotator.ensureValidToken(acc, "google-antigravity"),
+        rotator.ensureValidToken(acc, "google-antigravity"),
+        rotator.ensureValidToken(acc, "google-antigravity"),
+      ]);
+
+      // Single-flight must ensure exactly 1 adapter refresh was initiated
+      assert.equal(adapterRefreshCalls, 1, "Adapter ensureValidToken must be called exactly once across concurrent callers");
+      assert.equal(acc.accessToken, "refreshed-token", "Waiters must observe refreshed token on runtime");
+    } finally {
+      adapter.ensureValidToken = originalEnsureValid;
+    }
+  });
+
+  it("does not coalesce refresh flights for distinct accounts with same email but different projects", async () => {
+    const acc1 = makeAccount("shared@example.com", "proj-1", "claude", 100);
+    const acc2 = makeAccount("shared@example.com", "proj-2", "claude", 100);
+    const rotator = new AccountRotator({
+      proxyPort: 51209,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc1.config, acc2.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2];
+
+    let refreshCalls = 0;
+    const adapter = getProviderAdapter("google-antigravity");
+    const originalEnsureValid = adapter.ensureValidToken.bind(adapter);
+    adapter.ensureValidToken = async (account: AccountRuntime) => {
+      refreshCalls++;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      account.accessToken = `refreshed-${account.config.projectId}`;
+    };
+
+    try {
+      await Promise.all([
+        rotator.ensureValidToken(acc1, "google-antigravity"),
+        rotator.ensureValidToken(acc2, "google-antigravity"),
+      ]);
+
+      assert.equal(refreshCalls, 2, "Distinct accounts must not coalesce refresh flights");
+      assert.equal(acc1.accessToken, "refreshed-proj-1");
+      assert.equal(acc2.accessToken, "refreshed-proj-2");
+    } finally {
+      adapter.ensureValidToken = originalEnsureValid;
+    }
+  });
+
+  it("initial polling timeout is cancelled by stopQuotaPolling and triggers zero network/poll calls", async () => {
+    let pollCalls = 0;
+    const acc = makeAccount("polling@example.com", "proj-poll", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51211,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    (rotator as any).pollAllQuotas = async () => {
+      pollCalls++;
+    };
+
+    // Immediately stop polling
+    rotator.stopQuotaPolling();
+
+    // Verify both initial timeout and recurring interval handles are nullified
+    assert.equal((rotator as any).quotaInitialPollTimer, null, "quotaInitialPollTimer must be null after stopQuotaPolling");
+    assert.equal((rotator as any).quotaPollTimer, null, "quotaPollTimer must be null after stopQuotaPolling");
+
+    // Wait past the 2-second initial timeout threshold to confirm zero poll calls happen
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(pollCalls, 0, "No poll calls must occur when stopQuotaPolling is called");
+  });
+
+  it("replaceConfig does not transfer runtime state between duplicate-email accounts with different projects", async () => {
+    const accA = makeAccount("same@example.com", "project-a", "claude", 100);
+    accA.totalRequests = 10;
+    accA.tokenBucket = { tokens: 10, lastRefillAt: Date.now() };
+
+    const accB = makeAccount("same@example.com", "project-b", "claude", 100);
+    accB.totalRequests = 50;
+    accB.tokenBucket = { tokens: 40, lastRefillAt: Date.now() };
+
+    const rotator = new AccountRotator({
+      proxyPort: 51212,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accA.config, accB.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [accA, accB];
+
+    // Replace config removing Account A and retaining Account B
+    await rotator.replaceConfig({
+      proxyPort: 51212,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accB.config],
+    });
+
+    const accountsAfter = (rotator as any).accounts as AccountRuntime[];
+    assert.equal(accountsAfter.length, 1);
+    assert.equal(accountsAfter[0], accB, "Must retain accB runtime object reference");
+    assert.equal(accountsAfter[0].totalRequests, 50, "accB totalRequests must remain 50, not overwritten by accA");
+    assert.equal(accountsAfter[0].tokenBucket.tokens, 40, "accB token bucket must remain 40, not overwritten by accA");
+  });
+
+  it("stale in-flight refresh does not overwrite newly configured credentials across replaceConfig", async () => {
+    const acc = makeAccount("creds@example.com", "proj-c", "claude", 100);
+    acc.config.credentials = [{ provider: "google-antigravity", refreshToken: "refresh-old" }];
+
+    const rotator = new AccountRotator({
+      proxyPort: 51213,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc];
+
+    let oldRefreshRelease: (() => void) | null = null;
+    const oldRefreshBlocked = new Promise<void>((resolve) => {
+      oldRefreshRelease = resolve;
+    });
+
+    const adapter = getProviderAdapter("google-antigravity");
+    const originalEnsureValid = adapter.ensureValidToken.bind(adapter);
+    let calls = 0;
+    adapter.ensureValidToken = async (account: AccountRuntime) => {
+      calls++;
+      const cred = account.config.credentials?.find((c) => c.provider === "google-antigravity");
+      if (cred?.refreshToken === "refresh-old") {
+        await oldRefreshBlocked;
+        account.accessToken = "token-from-refresh-old";
+        return;
+      }
+      account.accessToken = "token-from-refresh-new";
+    };
+
+    try {
+      // 1. Start refresh using refresh-old (will block)
+      const refresh1Promise = rotator.ensureValidToken(acc, "google-antigravity");
+
+      // 2. While refresh1 is blocked, replace configuration with refresh-new
+      await rotator.replaceConfig({
+        proxyPort: 51213,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [
+          {
+            ...acc.config,
+            credentials: [{ provider: "google-antigravity", refreshToken: "refresh-new" }],
+          },
+        ],
+      });
+
+      // 3. Release blocked old refresh
+      oldRefreshRelease!();
+      await refresh1Promise;
+
+      // 4. Verify access token comes from refresh-new, not the stale refresh-old
+      assert.equal(acc.accessToken, "token-from-refresh-new", "Access token must come from newly configured credentials");
+      assert.equal(calls, 2, "Must perform second refresh with the new credential generation");
+    } finally {
+      adapter.ensureValidToken = originalEnsureValid;
+    }
+  });
+
+  it("concurrent activations do not increment the wrong account's rotation counter", async () => {
+    const acc1 = makeAccount("acc1@example.com", "proj-1", "claude", 0); // 0% quota forces rotation
+    const acc2 = makeAccount("acc2@example.com", "proj-2", "claude", 100);
+    const acc3 = makeAccount("acc3@example.com", "proj-3", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51214,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [acc1.config, acc2.config, acc3.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc1, acc2, acc3];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 0,
+      requestsOnActiveAccount: 0,
+    });
+
+    let barrierReached: (() => void) | null = null;
+    const reachedPromise = new Promise<void>((resolve) => {
+      barrierReached = resolve;
+    });
+    let barrierRelease: (() => void) | null = null;
+    const releasePromise = new Promise<void>((resolve) => {
+      barrierRelease = resolve;
+    });
+
+    const originalSaveState = (rotator as any).saveState.bind(rotator);
+    let intercepted = false;
+    (rotator as any).saveState = async () => {
+      if (!intercepted) {
+        intercepted = true;
+        barrierReached!();
+        await releasePromise;
+      }
+      return originalSaveState();
+    };
+
+    // 1. Launch Request 1 (reserves acc2, pauses in saveState)
+    const req1Promise = rotator.getActiveAccount("claude-opus-4-6-thinking");
+    await reachedPromise;
+
+    // 2. Launch Request 2 (sees acc2 busy with inFlight=1, reserves acc3 and completes)
+    const req2 = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.equal(req2?.config.email, "acc3@example.com");
+
+    const stateWhileReq1Paused = (rotator as any).modelState.get("claude");
+    assert.equal(stateWhileReq1Paused.requestsOnActiveAccount, 1, "acc3 requestsOnActiveAccount must be 1");
+
+    // 3. Release Request 1
+    barrierRelease!();
+    const req1 = await req1Promise;
+    assert.equal(req1?.config.email, "acc2@example.com");
+
+    // 4. Assert acc3's counter did NOT get incremented a second time by req1 completion
+    const finalState = (rotator as any).modelState.get("claude");
+    assert.equal(
+      finalState.requestsOnActiveAccount,
+      1,
+      "Active account (acc3) must end at exactly 1 request (not 2)",
+    );
+
+    rotator.finishRequest(req1!, "claude");
+    rotator.finishRequest(req2!, "claude");
+  });
+
+  it("rotateToNext excludes explicitly failed account even when modelState shifted to another account", async () => {
+    const accA = makeAccount("accA@example.com", "proj-a", "claude", 100);
+    const accB = makeAccount("accB@example.com", "proj-b", "claude", 100);
+    const accC = makeAccount("accC@example.com", "proj-c", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51215,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      maxConcurrentRequestsPerAccount: 1,
+      maxConcurrentRequestsPerProjectModel: 1,
+      accounts: [accA.config, accB.config, accC.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [accA, accB, accC];
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 0,
+      stickyAccountIndex: 0,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 0,
+    });
+
+    // 1. Start request on accA
+    const activeA = await rotator.getActiveAccount("claude-opus-4-6-thinking");
+    assert.equal(activeA, accA);
+
+    // 2. Replace config while active
+    await rotator.replaceConfig({
+      proxyPort: 51215,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accA.config, accB.config, accC.config],
+    });
+
+    // 3. Another request moves modelState to accB (index 1)
+    (rotator as any).modelState.set("claude", {
+      activeAccountIndex: 1, // Currently points to accB
+      stickyAccountIndex: 1,
+      quotaAtRotationStart: 100,
+      requestsOnActiveAccount: 1,
+    });
+
+    // 4. Request on accA fails without cooldown or markExhausted
+    rotator.finishRequest(activeA!, "claude");
+    assert.equal(accA.cooldownsByModel["claude"] ?? 0, 0, "No cooldown on accA");
+
+    // 5. Call rotateToNext with failedAccount = activeA
+    const nextAccount = await rotator.rotateToNext("claude-opus-4-6-thinking", activeA!);
+    assert.ok(nextAccount);
+    assert.notEqual(
+      nextAccount.config.email,
+      "accA@example.com",
+      "Must exclude failed account A, even though modelState was pointing to B",
+    );
+  });
+
+  it("same-generation in-flight refresh is preserved and joined across replaceConfig", async () => {
+    const acc = makeAccount("preserveflight@example.com", "proj-pf", "claude", 100);
+    acc.config.credentials = [{ provider: "google-antigravity", refreshToken: "refresh-v1" }];
+
+    const rotator = new AccountRotator({
+      proxyPort: 51216,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc];
+
+    let barrierRelease: (() => void) | null = null;
+    const barrierBlocked = new Promise<void>((resolve) => {
+      barrierRelease = resolve;
+    });
+
+    const adapter = getProviderAdapter("google-antigravity");
+    const originalEnsureValid = adapter.ensureValidToken.bind(adapter);
+    let adapterCalls = 0;
+    adapter.ensureValidToken = async (account: AccountRuntime) => {
+      adapterCalls++;
+      await barrierBlocked;
+      account.accessToken = "token-v1";
+      account.tokenExpires = Date.now() + 3600000;
+    };
+
+    try {
+      // 1. Start refresh for refresh-v1 (blocks at barrier)
+      const flight1 = rotator.ensureValidToken(acc, "google-antigravity");
+
+      // 2. Replace config with updated label while flight1 is active, retaining same credential generation
+      await rotator.replaceConfig({
+        proxyPort: 51216,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [
+          {
+            ...acc.config,
+            label: "Updated Label Only",
+            credentials: [{ provider: "google-antigravity", refreshToken: "refresh-v1" }],
+          },
+        ],
+      });
+
+      // 3. Second caller asks for token on the same account
+      const flight2 = rotator.ensureValidToken(acc, "google-antigravity");
+
+      // 4. Release barrier
+      barrierRelease!();
+      await Promise.all([flight1, flight2]);
+
+      // Assert single flight was joined across replaceConfig
+      assert.equal(adapterCalls, 1, "Must join existing flight and execute adapter exactly once for same credential generation");
+      assert.equal(acc.accessToken, "token-v1", "Waiters must observe refreshed token on runtime");
+      assert.equal(acc.config.label, "Updated Label Only");
+    } finally {
+      adapter.ensureValidToken = originalEnsureValid;
+    }
+  });
+
+  it("Codex persistence failure executes exactly one refresh and propagates persistence error without unpersisted publication", async () => {
+    const acc = makeAccount("codexpersist@example.com", "proj-cp", "claude", 100);
+    acc.config.credentials = [{ provider: "openai-codex", refreshToken: "codex-refresh-1" }];
+
+    const rotator = new AccountRotator({
+      proxyPort: 51217,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc];
+
+    const adapter = getProviderAdapter("openai-codex");
+    const originalEnsureValid = adapter.ensureValidToken.bind(adapter);
+    let attempts = 0;
+    adapter.ensureValidToken = async () => {
+      attempts++;
+      throw new Error("Could not persist the rotated Codex refresh token");
+    };
+
+    try {
+      await assert.rejects(
+        async () => {
+          await rotator.ensureValidToken(acc, "openai-codex");
+        },
+        /Could not persist the rotated Codex refresh token/,
+      );
+
+      assert.equal(attempts, 1, "Must execute exactly one refresh attempt and not retry on persistence failure");
+      assert.equal(acc.providerTokens?.["openai-codex"]?.accessToken ?? null, null, "Unpersisted access token must not be published");
+    } finally {
+      adapter.ensureValidToken = originalEnsureValid;
+    }
+  });
+
+  it("duplicate-email accounts without stable IDs are distinguished by secret fingerprint and isolate runtime state", async () => {
+    const accA = makeAccount("dup@example.com", undefined, "claude", 100);
+    delete (accA.config as any).projectId;
+    accA.config.credentials = [{ provider: "openai-codex", refreshToken: "secret-token-A" }];
+    accA.totalRequests = 15;
+    accA.tokenBucket = { tokens: 15, lastRefillAt: Date.now() };
+
+    const accB = makeAccount("dup@example.com", undefined, "claude", 100);
+    delete (accB.config as any).projectId;
+    accB.config.credentials = [{ provider: "openai-codex", refreshToken: "secret-token-B" }];
+    accB.totalRequests = 75;
+    accB.tokenBucket = { tokens: 45, lastRefillAt: Date.now() };
+
+    const rotator = new AccountRotator({
+      proxyPort: 51218,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accA.config, accB.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [accA, accB];
+
+    // Replace config retaining only Account B
+    await rotator.replaceConfig({
+      proxyPort: 51218,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accB.config],
+    });
+
+    const accountsAfter = (rotator as any).accounts as AccountRuntime[];
+    assert.equal(accountsAfter.length, 1);
+    assert.equal(accountsAfter[0], accB, "Must match accB runtime exactly via secret fingerprint");
+    assert.equal(accountsAfter[0].totalRequests, 75, "accB totalRequests must remain 75, not overwritten by accA");
+    assert.equal(accountsAfter[0].tokenBucket.tokens, 45, "accB token bucket must remain 45, not overwritten by accA");
+  });
+
+  it("cross-provider refresh publication isolates state in both directions", async () => {
+    const acc = makeAccount("dual@example.com", "proj-dual", "claude", 100);
+    acc.config.credentials = [
+      { provider: "google-antigravity", refreshToken: "google-refresh-1" },
+      { provider: "openai-codex", refreshToken: "codex-refresh-1" },
+    ];
+    acc.accessToken = "initial-google-token";
+    acc.tokenExpires = Date.now() + 3600000;
+    acc.providerTokens = {
+      "openai-codex": { accessToken: "initial-codex-token", tokenExpires: Date.now() + 3600000 },
+    };
+
+    const rotator = new AccountRotator({
+      proxyPort: 51219,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc];
+
+    let googleBlocked: (() => void) | null = null;
+    const googleBarrier = new Promise<void>((resolve) => {
+      googleBlocked = resolve;
+    });
+
+    const googleAdapter = getProviderAdapter("google-antigravity");
+    const codexAdapter = getProviderAdapter("openai-codex");
+    const origGoogle = googleAdapter.ensureValidToken.bind(googleAdapter);
+    const origCodex = codexAdapter.ensureValidToken.bind(codexAdapter);
+
+    googleAdapter.ensureValidToken = async (account: AccountRuntime) => {
+      await googleBarrier;
+      account.accessToken = "refreshed-google-token";
+      account.tokenExpires = Date.now() + 3600000;
+    };
+
+    codexAdapter.ensureValidToken = async (account: AccountRuntime) => {
+      account.providerTokens = {
+        "openai-codex": { accessToken: "refreshed-codex-token", tokenExpires: Date.now() + 3600000 },
+      };
+      const codexCred = account.config.credentials?.find((c) => c.provider === "openai-codex");
+      if (codexCred) codexCred.refreshToken = "rotated-codex-refresh";
+    };
+
+    try {
+      // 1. Direction 1: Start Google refresh (blocked)
+      const googleFlight = rotator.ensureValidToken(acc, "google-antigravity");
+
+      // 2. Refresh Codex while Google is in-flight
+      await rotator.ensureValidToken(acc, "openai-codex");
+      assert.equal(acc.providerTokens?.["openai-codex"]?.accessToken, "refreshed-codex-token");
+
+      // 3. Release Google refresh
+      googleBlocked!();
+      await googleFlight;
+
+      // 4. Assert Google refresh updated Google tokens WITHOUT overwriting Codex tokens/credentials
+      assert.equal(acc.accessToken, "refreshed-google-token");
+      assert.equal(
+        acc.providerTokens?.["openai-codex"]?.accessToken,
+        "refreshed-codex-token",
+        "Google refresh completion must not overwrite Codex providerTokens",
+      );
+      const codexCredAfter = acc.config.credentials?.find((c) => c.provider === "openai-codex");
+      assert.equal(
+        codexCredAfter?.refreshToken,
+        "rotated-codex-refresh",
+        "Google refresh completion must not overwrite Codex credentials entry",
+      );
+    } finally {
+      googleAdapter.ensureValidToken = origGoogle;
+      codexAdapter.ensureValidToken = origCodex;
+    }
+  });
+
+  it("Google projectId does not hide Codex secret fingerprint for dual accounts without Codex ID", async () => {
+    const accA = makeAccount("dual-same@example.com", "shared-google-proj", "claude", 100);
+    accA.config.credentials = [
+      { provider: "google-antigravity", projectId: "shared-google-proj", refreshToken: "g-ref" },
+      { provider: "openai-codex", refreshToken: "codex-secret-A" },
+    ];
+    accA.totalRequests = 12;
+
+    const accB = makeAccount("dual-same@example.com", "shared-google-proj", "claude", 100);
+    accB.config.credentials = [
+      { provider: "google-antigravity", projectId: "shared-google-proj", refreshToken: "g-ref" },
+      { provider: "openai-codex", refreshToken: "codex-secret-B" },
+    ];
+    accB.totalRequests = 88;
+
+    const rotator = new AccountRotator({
+      proxyPort: 51220,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accA.config, accB.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [accA, accB];
+
+    // Replace config retaining only Account B
+    await rotator.replaceConfig({
+      proxyPort: 51220,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [accB.config],
+    });
+
+    const accountsAfter = (rotator as any).accounts as AccountRuntime[];
+    assert.equal(accountsAfter.length, 1);
+    assert.equal(accountsAfter[0], accB, "Must retain accB runtime based on Codex secret fingerprint");
+    assert.equal(accountsAfter[0].totalRequests, 88, "accB totalRequests must remain 88, not overwritten by accA");
+  });
+
+  it("retry does not exclude a healthy replacement runtime after failed incarnation is removed", async () => {
+    const oldFailedRuntime = makeAccount("replace@example.com", "proj-rep", "claude", 100);
+    const newHealthyRuntime = makeAccount("replace@example.com", "proj-rep", "claude", 100);
+
+    const rotator = new AccountRotator({
+      proxyPort: 51221,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [newHealthyRuntime.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [newHealthyRuntime];
+
+    // Failed old runtime was removed / replaced. Now proxy calls rotateToNext with oldFailedRuntime.
+    const result = await rotator.rotateToNext("claude-opus-4-6-thinking", oldFailedRuntime);
+    assert.ok(result, "rotateToNext must return the healthy replacement runtime, not exclude it with false 503");
+    assert.equal(result, newHealthyRuntime, "Must return the healthy new incarnation");
+  });
+
+  it("top-level Google refresh token change triggers generation change and discards stale refresh", async () => {
+    const acc = makeAccount("toplevel@example.com", "proj-tl", "claude", 100);
+    acc.config.refreshToken = "google-top-old";
+    delete acc.config.credentials;
+
+    const rotator = new AccountRotator({
+      proxyPort: 51222,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [acc.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [acc];
+
+    let oldBlocked: (() => void) | null = null;
+    const oldBarrier = new Promise<void>((resolve) => {
+      oldBlocked = resolve;
+    });
+
+    const adapter = getProviderAdapter("google-antigravity");
+    const origEnsure = adapter.ensureValidToken.bind(adapter);
+    let calls = 0;
+    adapter.ensureValidToken = async (account: AccountRuntime) => {
+      calls++;
+      if (account.config.refreshToken === "google-top-old") {
+        await oldBarrier;
+        account.accessToken = "access-from-top-old";
+        return;
+      }
+      account.accessToken = "access-from-top-new";
+    };
+
+    try {
+      const flight1 = rotator.ensureValidToken(acc, "google-antigravity");
+
+      // Replace top-level refreshToken
+      await rotator.replaceConfig({
+        proxyPort: 51222,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [
+          {
+            email: acc.config.email,
+            projectId: acc.config.projectId,
+            refreshToken: "google-top-new",
+          },
+        ],
+      });
+
+      oldBlocked!();
+      await flight1;
+
+      assert.equal(acc.accessToken, "access-from-top-new", "Must discard access-from-top-old and refresh with google-top-new");
+      assert.equal(calls, 2);
+    } finally {
+      adapter.ensureValidToken = origEnsure;
+    }
+  });
+});


### PR DESCRIPTION
## Description

This pull request resolves resilience issues on 429 (`RESOURCE_EXHAUSTED`) errors, concurrency races in account leasing and assignment accounting, cross-provider token refresh isolation, and account identity consistency across configuration updates.

---

### Key Changes

#### 1. Account-Scoped 429 `RESOURCE_EXHAUSTED` Resilience
- **Issue**: When an account exhausted its individual quota (returning 429 `RESOURCE_EXHAUSTED` on Claude or Gemini), the proxy failed to fall back to the remaining eligible accounts in the pool, prematurely bubbling the 429 error up to the client.
- **Fix ([src/proxy.ts](file:///Users/javargasm91/Laboral/Personal/repos/pi-antigravity-rotator/src/proxy.ts))**: The proxy now distinguishes account-scoped exhaustion (`RESOURCE_EXHAUSTED`) from global rate limits. Upon encountering account quota exhaustion, it marks the account in cooldown and automatically retries the request with the next eligible account in the pool instead of failing immediately.

#### 2. Concurrency Safety & Synchronous Leasing
- **Issue**: `getActiveAccount()` performed asynchronous tasks (`saveAccountsConfig`, token refreshes) before acquiring the account lease. This allowed concurrent requests to acquire the same account, violating concurrency limits (`inFlight=2` when configured limit is 1). Additionally, concurrent activations could misattribute rotation request counters.
- **Fix ([src/rotator.ts](file:///Users/javargasm91/Laboral/Personal/repos/pi-antigravity-rotator/src/rotator.ts))**:
  - Account `inFlight` increment and model assignment tracking (`requestsOnActiveAccount`) occur synchronously and indivisibly at lease time.
  - Added strict rollback for `inFlight` and refund of `tokenBucket` if account activation or token refresh fails prior to request dispatch.

#### 3. Snapshot-Based Provider Token Refresh Execution
- **Issue**: Provider adapters mutated the live `AccountRuntime` object in-memory during asynchronous network requests. Concurrent `replaceConfig()` updates or persistence failures could overwrite freshly configured credentials with stale snapshot data or trigger redundant retries.
- **Fix ([src/rotator.ts](file:///Users/javargasm91/Laboral/Personal/repos/pi-antigravity-rotator/src/rotator.ts))**:
  - `ensureValidTokenForProvider` executes refreshes against an isolated `snapshotAccount` clone.
  - Upon completion, it validates whether `getCredentialGeneration(account, providerId) === startGen`. If credentials changed in flight, stale results are discarded cleanly and the caller joins/starts the flight for the active generation.
  - For OpenAI Codex, rotating refresh token persistence failures (`persistCodexRefreshToken`) propagate immediately without unpersisted credential publication or redundant retry loops.

#### 4. Provider-Scoped Token Publication
- **Issue**: Post-refresh token publication previously copied global fields (`accessToken`, full `providerTokens`, full `credentials` array), causing Google refreshes to overwrite newly updated Codex credentials/tokens and vice versa.
- **Fix ([src/rotator.ts](file:///Users/javargasm91/Laboral/Personal/repos/pi-antigravity-rotator/src/rotator.ts))**: Each provider refresh publishes strictly the fields owned by `providerId` (Google updates only `accessToken`, `tokenExpires`, Google `refreshToken`, and its entry in `credentials`; Codex updates only `providerTokens["openai-codex"]`, `codexRefreshToken`, and its entry in `credentials`).

#### 5. Identity Resolution & Non-Secret Fingerprinting
- **Issue**: Accounts sharing an email without stable IDs (`projectId` or `providerAccountId`) cross-wired runtime state during `replaceConfig()`. Furthermore, top-level Google `projectId` masked Codex secret fingerprint calculation.
- **Fix ([src/rotator.ts](file:///Users/javargasm91/Laboral/Personal/repos/pi-antigravity-rotator/src/rotator.ts))**:
  - `getProviderCredentialDetails()` isolates legacy fallbacks strictly per provider.
  - A 12-character non-secret SHA-256 fingerprint is generated for credentials lacking stable IDs.
  - `replaceConfig()` and `rotateToNext()` strictly require exact matches or uniquely resolvable candidates (`matchingIndices.length === 1`), creating clean runtimes conservatively when identity is ambiguous.

#### 6. Exact Incarnation Exclusion on Retry
- **Issue**: When `rotateToNext()` received a `failedAccount` object that was removed and re-added, matching by logical identity excluded the new healthy incarnation, resulting in false 503 errors.
- **Fix ([src/rotator.ts](file:///Users/javargasm91/Laboral/Personal/repos/pi-antigravity-rotator/src/rotator.ts))**: Object exclusion is strictly bound to the exact runtime instance (`this.accounts.indexOf(failedAccount)`). If the failed instance is no longer in the active array, it does not exclude the healthy replacement.

---

## Test Verification

- **Resilience Test Suite**: `test/rotator-429-resilience.test.ts` (**23 / 23 tests PASSED**).
- **Proxy E2E Suite**: `test/proxy-e2e.test.ts` (**19 / 19 tests PASSED**).
- **Full Quality Check**: `npm run check` (**624 / 624 tests PASSED** across 106 suites, 0 TypeScript errors, 0 ESLint errors).
- **Format Hygiene**: `git diff --check HEAD` (**0 errors**).