### PR TITLE
fix(rotator): harden quota cooldowns and preserve idle pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ DEVELOPMENT_NOTES.md
 .DS_Store
 ollama-debug-last.json
 .codegraph/
+.atl/

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -199,8 +199,9 @@ Flagged accounts are **immediately excluded** from all model routing. If the rea
 
 ## Cooldown Management
 
-- Cooldowns are capped at **30 minutes** max
-- Stale cooldowns from previous sessions are capped on startup
+- Generic rate-limit cooldowns are capped at **30 minutes** max
+- Explicit reset durations reported by Antigravity `RESOURCE_EXHAUSTED` responses are honored in full; the generic 30-minute cap does not truncate them
+- Stale generic cooldowns from previous sessions are capped on startup, while persisted Antigravity Claude/Gemini reset deadlines are preserved
 - When every non-flagged account is cooling down, the routing state becomes `cooldown_wait`
 - The dashboard shows why routing is waiting, how long until the next retry window, and which accounts are cooling down
 - Quota-based rotation only triggers if a healthy account is available; the proxy won't rotate away from a working account if there's no better alternative

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -17,30 +17,37 @@ Create or edit `~/.config/opencode/opencode.json` (global) or `opencode.json` in
         "baseURL": "http://localhost:51200/v1"
       },
       "models": {
+        "gemini-3.7-flash-tiered": {
+          "name": "Gemini 3.7 Flash Tiered (Thinking)",
+          "limit": { "context": 1000000, "output": 65536 },
+          "options": {
+            "reasoningEffort": "high"
+          }
+        },
         "gemini-3.6-flash-high": {
           "name": "Gemini 3.6 Flash High",
-          "limit": { "context": 200000, "output": 65536 }
+          "limit": { "context": 1000000, "output": 65536 }
         },
         "gemini-3.6-flash-medium": {
           "name": "Gemini 3.6 Flash Medium",
-          "limit": { "context": 200000, "output": 65536 }
+          "limit": { "context": 1000000, "output": 65536 }
         },
         "gemini-3.1-pro-low": {
           "name": "Gemini 3.1 Pro",
-          "limit": { "context": 200000, "output": 65536 }
+          "limit": { "context": 1000000, "output": 65536 }
         },
         "claude-sonnet-4-6": {
           "name": "Claude Sonnet 4.6",
-          "limit": { "context": 200000, "output": 65536 }
+          "limit": { "context": 1000000, "output": 64000 }
         },
         "claude-opus-4-6-thinking": {
           "name": "Claude Opus 4.6 Thinking",
-          "limit": { "context": 200000, "output": 65536 }
+          "limit": { "context": 1000000, "output": 64000 }
         }
       }
     }
   },
-  "model": "antigravity/gemini-3.6-flash-high"
+  "model": "antigravity/gemini-3.7-flash-tiered"
 }
 ```
 
@@ -76,19 +83,68 @@ Then set `TUXEVIL_ROTATOR_KEY=no-key` (or your `rk-...` key) in your shell.
 Set as default in config:
 
 ```json
-{ "model": "antigravity/gemini-3.6-flash-high" }
+{ "model": "antigravity/gemini-3.7-flash-tiered" }
 ```
 
 Or via CLI flag:
 
 ```bash
-opencode --model antigravity/gemini-3.6-flash-high
+opencode --model antigravity/gemini-3.7-flash-tiered
 ```
 
 Or use `/models` inside OpenCode to pick interactively.
+
+## Thinking & Reasoning Levels
+
+Antigravity models handle reasoning and internal thinking in two ways:
+
+### 1. Adaptive Thinking (`gemini-3.7-flash-tiered`)
+
+`gemini-3.7-flash-tiered` uses Google's dynamic thinking level. By default, it operates adaptively (the model decides how many tokens to think). You can control the thinking depth using standard `reasoning_effort`:
+
+| Level | Upstream `thinkingLevel` | Use Case |
+| :--- | :--- | :--- |
+| **`low`** | `LOW` | Quick responses, straightforward edits, simple questions. |
+| **`medium`** | `MEDIUM` | Balanced reasoning for standard coding and multi-file refactors. |
+| **`high`** | `HIGH` | Deep architectural design, complex bug diagnosis, deep multi-step planning. |
+| *(default)* | Adaptive | Model dynamically adjusts thinking tokens based on prompt complexity. |
+
+### 2. Fixed Token Budgets (Gemini 3.6 / 3.1 & Claude)
+
+For earlier Gemini models and Claude, the thinking budget is predetermined by model ID:
+
+| Model ID | Context Window | Thinking Budget |
+| :--- | :--- | :--- |
+| `gemini-3.7-flash-tiered` | 1,000,000 | Dynamic / Tiered (`low` / `medium` / `high`) |
+| `gemini-3.6-flash-high` | 1,000,000 | 10,000 tokens (fixed) |
+| `gemini-3.6-flash-medium` | 1,000,000 | 4,000 tokens (fixed) |
+| `gemini-3.6-flash-low` | 1,000,000 | 1,000 tokens (fixed) |
+| `gemini-3.1-pro-low` | 1,000,000 | 1,001 tokens (fixed) |
+| `claude-sonnet-4-6` | 1,000,000 | 32,768 tokens (fixed) |
+| `claude-opus-4-6-thinking` | 1,000,000 | 32,768 tokens (fixed) |
+
+## Advanced Settings & Prompt Compression
+
+You can pass custom headers in `opencode.json` to enable features like token compression:
+
+```jsonc
+{
+  "provider": {
+    "antigravity": {
+      "options": {
+        "baseURL": "http://localhost:51200/v1",
+        "headers": {
+          "X-Rotator-Compression": "rtk+lite"
+        }
+      }
+    }
+  }
+}
+```
 
 ## Notes
 
 - The `npm` field must be `"@ai-sdk/openai-compatible"` for the OpenAI Chat Completions endpoint
 - Model IDs in the config must match what `GET /v1/models` returns from the rotator
 - Add as many models as you want to the `models` map — only listed ones appear in the picker
+- `tuxevil-rotator` automatically sanitizes complex JSON schemas sent by OpenCode tools (`read`, `edit`, `shell`, `task`, `grep`, `glob`), stripping unsupported keywords so Antigravity executes them seamlessly.

--- a/src/providers/google-antigravity/index.ts
+++ b/src/providers/google-antigravity/index.ts
@@ -162,7 +162,10 @@ export const googleAntigravityAdapter: ProviderAdapter = {
   createStreamAccumulator: createGoogleStreamAccumulator,
 
   getKickstartModelForPool(quotaModelKey: string): string | undefined {
-    return KICKSTART_MODEL_FOR_QUOTA_POOL[quotaModelKey];
+    return (
+      KICKSTART_MODEL_FOR_QUOTA_POOL[quotaModelKey] ??
+      KICKSTART_MODEL_FOR_QUOTA_POOL[resolveQuotaModelKey(quotaModelKey) ?? ""]
+    );
   },
 
   ownsModel(model: string): boolean {

--- a/src/providers/google-antigravity/quota.ts
+++ b/src/providers/google-antigravity/quota.ts
@@ -39,7 +39,11 @@ export function extractQuotas(
     }
 
     if (modelInfo?.quotaInfo) {
-      const resetTime = modelInfo.quotaInfo.resetTime ?? null;
+      const remainingFraction = modelInfo.quotaInfo.remainingFraction ?? 0;
+      // Google can publish a nominal reset for an untouched pool; no usage means
+      // there is no active quota window yet.
+      const resetTime =
+        remainingFraction >= 1 ? null : modelInfo.quotaInfo.resetTime ?? null;
       let timerType: ModelQuota["timerType"] = "fresh";
 
       if (resetTime) {
@@ -63,9 +67,7 @@ export function extractQuotas(
       quotas.push({
         modelKey: config.key,
         displayName: config.display,
-        percentRemaining: Math.round(
-          (modelInfo.quotaInfo.remainingFraction ?? 0) * 100,
-        ),
+        percentRemaining: Math.round(remainingFraction * 100),
         resetTime,
         timerType,
       });

--- a/src/providers/ollama/index.ts
+++ b/src/providers/ollama/index.ts
@@ -27,6 +27,8 @@ const OLLAMA_TIER_RANKING = {
   unknown: 4,
 };
 
+const OLLAMA_KICKSTART_MODEL = "gpt-oss:20b";
+
 export const ollamaAdapter: ProviderAdapter = {
   id: "ollama",
   displayName: "Ollama Cloud",
@@ -74,11 +76,12 @@ export const ollamaAdapter: ProviderAdapter = {
 
   getKickstartModelForPool(quotaModelKey: string): string | undefined {
     // Only the session pool can be kickstarted for Ollama accounts.
-    return quotaModelKey === "session" ? "gpt-oss:20b" : undefined;
+    return quotaModelKey === "session" ? OLLAMA_KICKSTART_MODEL : undefined;
   },
 
   ownsModel(model: string, context?: { ollamaModels?: Set<string> }): boolean {
-    return context?.ollamaModels?.has(model) ?? false;
+    return model === OLLAMA_KICKSTART_MODEL ||
+      (context?.ollamaModels?.has(model) ?? false);
   },
 
   getPoolKey(): string {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -150,6 +150,7 @@ import { applyConfigDefaults } from "./account-store.js";
 import {
   classifyRateLimitReason,
   parseRetryAfterMs,
+  RESOURCE_EXHAUSTED_FALLBACK_MS,
 } from "./rate-limit-parser.js";
 import { authenticateVirtualKey, sendAuthErrorResponse } from "./key-auth.js";
 import { logSpend } from "./spend-logger.js";
@@ -160,7 +161,6 @@ const GENERIC_UPSTREAM_ERROR = "Upstream request failed";
 
 const DEFAULT_STREAM_RECOVERY_MAX_RETRIES = 2;
 const MAX_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes max cooldown
-const RESOURCE_EXHAUSTED_COOLDOWN_MS = 30 * 60 * 1000; // Stop hammering provider-side daily/request buckets
 const STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000; // Release account if a stream goes silent.
 const LARGE_CONTEXT_WARN_BYTES = 1 * 1024 * 1024;
 
@@ -299,13 +299,20 @@ export async function classifyUpstreamResponse(
   account: AccountRuntime,
   model: string,
   modelKey: string,
+  providerId = DEFAULT_PROVIDER,
 ): Promise<UpstreamAction> {
   if (response.status === 429) {
     const errorText = await response.text().catch(() => "");
     const rateLimitReason = classifyRateLimitReason(errorText, response.status);
     const providerResourceExhausted = rateLimitReason === "quota-exhausted";
     const cooldownMs = providerResourceExhausted
-      ? RESOURCE_EXHAUSTED_COOLDOWN_MS
+      ? providerId === DEFAULT_PROVIDER
+        ? parseRetryAfterMs(
+            errorText,
+            response.headers,
+            RESOURCE_EXHAUSTED_FALLBACK_MS,
+          )
+        : RESOURCE_EXHAUSTED_FALLBACK_MS
       : capCooldown(parseRetryAfterMs(errorText, response.headers));
     return {
       kind: "rate-limited",
@@ -1248,6 +1255,7 @@ export async function withRotation<T>(
         account,
         model,
         modelKey,
+        provider.id,
       );
 
       if (action.kind !== "success") {
@@ -1680,6 +1688,7 @@ async function handleProxyRequest(
         account,
         body.model,
         modelKey,
+        provider.id,
       );
 
       if (action.kind !== "success") {

--- a/src/rate-limit-parser.ts
+++ b/src/rate-limit-parser.ts
@@ -1,5 +1,7 @@
 export type RateLimitReason = "rate-limit" | "quota-exhausted" | "model-capacity" | "server-error" | "unknown";
 
+export const RESOURCE_EXHAUSTED_FALLBACK_MS = 30 * 60 * 1000;
+
 function parseDurationToMs(errorText: string): number | null {
 	const durationMatch = errorText.match(/(?:(\d+)h)?(?:(\d+)m)?(\d+(?:\.\d+)?)s/i);
 	if (!durationMatch) return null;
@@ -7,7 +9,8 @@ function parseDurationToMs(errorText: string): number | null {
 	const minutes = durationMatch[2] ? parseInt(durationMatch[2], 10) : 0;
 	const seconds = parseFloat(durationMatch[3]);
 	if (!Number.isFinite(seconds)) return null;
-	return Math.ceil(((hours * 60 + minutes) * 60 + seconds) * 1000);
+	const durationMs = ((hours * 60 + minutes) * 60 + seconds) * 1000;
+	return Number.isFinite(durationMs) ? Math.ceil(durationMs) : null;
 }
 
 export function classifyRateLimitReason(errorText: string, status?: number): RateLimitReason {
@@ -54,7 +57,11 @@ export function classifyRateLimitReason(errorText: string, status?: number): Rat
 	return "unknown";
 }
 
-export function parseRetryAfterMs(errorText: string, headers: Headers): number {
+export function parseRetryAfterMs(
+	errorText: string,
+	headers: Headers,
+	fallbackMs = 60_000,
+): number {
 	const retryAfter = headers.get("retry-after");
 	if (retryAfter) {
 		const seconds = Number(retryAfter);
@@ -123,5 +130,7 @@ export function parseRetryAfterMs(errorText: string, headers: Headers): number {
 	const duration = parseDurationToMs(errorText);
 	if (duration && duration > 0) return Math.ceil(duration + 1000);
 
-	return 60_000;
+	return Number.isFinite(fallbackMs) && fallbackMs > 0
+		? Math.ceil(fallbackMs)
+		: 60_000;
 }

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -855,6 +855,34 @@ export class AccountRotator {
       // Token refresh or quota fetch failed, skip this account
     }
 
+    let cooldownChanged = false;
+    if (account.lastPollByProvider?.[DEFAULT_PROVIDER] !== undefined) {
+      const now = Date.now();
+      for (const quota of account.quota) {
+        if (
+          quota.providerId !== DEFAULT_PROVIDER ||
+          quota.percentRemaining !== 0 ||
+          !quota.resetTime
+        ) {
+          continue;
+        }
+        const resetAt = new Date(quota.resetTime).getTime();
+        if (
+          !Number.isFinite(resetAt) ||
+          resetAt <= now ||
+          account.cooldownsByModel[quota.modelKey] === resetAt
+        ) {
+          continue;
+        }
+        account.cooldownsByModel[quota.modelKey] = resetAt;
+        cooldownChanged = true;
+      }
+    }
+    if (cooldownChanged) {
+      this.scheduleStateSave();
+      this.requestWaiterDrain();
+    }
+
     // Consolidated RAW POLL across all providers on this account:
     // google first (Antigravity OAuth pools), then ollama (usage pools).
     this.logConsolidatedPoll(account);

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -234,8 +234,8 @@ interface AccountRequestWaiter {
 
 // Reverse map: upstream model → the quota pool key it primarily represents (for deduplication).
 const QUOTA_POOL_FOR_KICKSTART_MODEL: Record<string, string> = {
-  "gpt-oss-120b-medium": "claude-opus-4-6-thinking",
-  "gemini-3-flash": "gemini-3.5-flash",
+  "gpt-oss-120b-medium": "claude",
+  "gemini-3-flash": "gemini",
 };
 
 export class AccountRotator {

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -83,6 +83,11 @@ import {
   getCachedTokenUsage,
   setCachedTokenUsage,
 } from "./db-store.js";
+import {
+  classifyRateLimitReason,
+  parseRetryAfterMs,
+  RESOURCE_EXHAUSTED_FALLBACK_MS,
+} from "./rate-limit-parser.js";
 
 function credentialFingerprint(secret?: string): string {
   if (!secret) return "";
@@ -234,8 +239,9 @@ interface AccountRequestWaiter {
 
 // Reverse map: upstream model → the quota pool key it primarily represents (for deduplication).
 const QUOTA_POOL_FOR_KICKSTART_MODEL: Record<string, string> = {
-  "gpt-oss-120b-medium": "claude-opus-4-6-thinking",
-  "gemini-3-flash": "gemini-3.5-flash",
+  "gpt-oss-120b-medium": "claude",
+  "gemini-3-flash": "gemini",
+  "gpt-oss:20b": "session",
 };
 
 export class AccountRotator {
@@ -247,6 +253,9 @@ export class AccountRotator {
   private startTime = Date.now();
   private quotaPollTimer: ReturnType<typeof setInterval> | null = null;
   private quotaInitialPollTimer: ReturnType<typeof setTimeout> | null = null;
+  private quotaPolls = new WeakMap<AccountRuntime, Promise<boolean>>();
+  private quotaRepollRequested = new WeakSet<AccountRuntime>();
+  private quotaPollCycle: Promise<void> | null = null;
   private inFlightRefreshes = new WeakMap<AccountRuntime, Map<string, Promise<void>>>();
   private requestCursorIndex = -1;
   private requestWaiters: AccountRequestWaiter[] = [];
@@ -372,9 +381,6 @@ export class AccountRotator {
   }> = [];
   private routingDiagnostics: Record<string, RoutingModelDiagnostics> = {};
   private autoWarmupEnabled = false;
-  // Tracks upstream models already warmed-up this poll cycle per account (email → Set<upstreamModel>).
-  // Cleared at the start of each pollAllQuotas() to enforce the one-per-cycle guarantee.
-  private warmupSentThisCycle = new Map<string, Set<string>>();
   // Debounced state writer: batches multiple saveState() calls within a 1s window
   // to a single disk write. Hot paths (markError, recordRequest, etc.) call
   // scheduleStateSave() instead of saveState() to avoid blocking the event loop.
@@ -576,14 +582,19 @@ export class AccountRotator {
             saved.allowFreshWindowStartsOverride ?? false;
         }
       }
-      // Cap any stale cooldowns to 30 min max from now
+      // Cap generic stale cooldowns to 30 min max from now. Antigravity's
+      // explicit Claude/Gemini reset deadlines must survive restarts intact.
       const maxCooldown = 30 * 60 * 1000;
       const now = Date.now();
       for (const account of this.accounts) {
         for (const [model, cooldown] of Object.entries(
           account.cooldownsByModel,
         )) {
-          if (cooldown > now + maxCooldown) {
+          if (
+            model !== "claude" &&
+            model !== "gemini" &&
+            cooldown > now + maxCooldown
+          ) {
             account.cooldownsByModel[model] = now + maxCooldown;
           }
         }
@@ -787,82 +798,97 @@ export class AccountRotator {
     account.lastPollByProvider = {};
   }
 
-  private async pollAllQuotas(): Promise<void> {
-    // Reset per-cycle warmup tracking so each poll cycle allows at most one warmup per upstream model per account.
-    this.warmupSentThisCycle.clear();
+  pollAccountQuota(account: AccountRuntime): Promise<boolean> {
+    const inFlight = this.quotaPolls.get(account);
+    if (inFlight) {
+      this.quotaRepollRequested.add(account);
+      return inFlight;
+    }
+
+    const run = (async (): Promise<boolean> => {
+      let quotaPublished = false;
+      do {
+        this.quotaRepollRequested.delete(account);
+        quotaPublished =
+          (await this.pollAccountQuotaOnce(account)) || quotaPublished;
+      } while (this.quotaRepollRequested.has(account));
+      return quotaPublished;
+    })();
+
+    const tracked = run.finally(() => {
+      this.quotaPolls.delete(account);
+    });
+    this.quotaPolls.set(account, tracked);
+    return tracked;
+  }
+
+  private async pollAccountQuotaOnce(account: AccountRuntime): Promise<boolean> {
+    let quotaPublished = false;
+    try {
+      const quotaCtx: QuotaFetchContext = {
+        log: (message) => this.log(message),
+        markFlagged: (acc, reason, options) =>
+          this.markFlagged(acc, reason, options),
+        reportQuotaPollFlag: (acc, statusCode, errorText) =>
+          this.reportQuotaPollFlag(acc, statusCode, errorText),
+        markProviderInvalid: (acc, providerId, reason) =>
+          this.markProviderInvalid(acc, providerId, reason),
+        setProviderCooldown: (acc, providerId, durationMs) =>
+          this.setProviderCooldown(acc, providerId, durationMs),
+      };
+      // Parent-account model: poll quota for every provider credential
+      // the account holds (Google OAuth pools + Ollama usage pools).
+      const providerIds = new Set<string>(
+        (account.config.credentials ?? []).map((c) => c.provider),
+      );
+      if (providerIds.size === 0) providerIds.add(primaryProviderId(account.config));
+      for (const pid of providerIds) {
+        try {
+          await this.ensureValidTokenForProvider(account, pid);
+          await getProviderAdapter(pid).fetchQuota(account, quotaCtx);
+          quotaPublished = true;
+        } catch {
+          // One invalid provider credential must not suppress sibling pools.
+        }
+      }
+    } catch {
+      // Token refresh or quota fetch failed, skip this account
+    }
+
+    // Consolidated RAW POLL across all providers on this account:
+    // google first (Antigravity OAuth pools), then ollama (usage pools).
+    this.logConsolidatedPoll(account);
+    return quotaPublished;
+  }
+
+  private pollAllQuotas(): Promise<void> {
+    if (this.quotaPollCycle) return this.quotaPollCycle;
+    this.quotaPollCycle = this.pollAllQuotasOnce().finally(() => {
+      this.quotaPollCycle = null;
+    });
+    return this.quotaPollCycle;
+  }
+
+  private async pollAllQuotasOnce(): Promise<void> {
     void this.refreshOllamaCatalogOnce().catch(() => {});
 
     const available = this.accounts.filter((a) => !a.disabled && !a.flagged);
     let quotaPublished = false;
     for (const account of available) {
-      try {
-        const quotaCtx: QuotaFetchContext = {
-          log: (message) => this.log(message),
-          markFlagged: (acc, reason, options) =>
-            this.markFlagged(acc, reason, options),
-          reportQuotaPollFlag: (acc, statusCode, errorText) =>
-            this.reportQuotaPollFlag(acc, statusCode, errorText),
-          markProviderInvalid: (acc, providerId, reason) =>
-            this.markProviderInvalid(acc, providerId, reason),
-          setProviderCooldown: (acc, providerId, durationMs) =>
-            this.setProviderCooldown(acc, providerId, durationMs),
-        };
-        // Parent-account model: poll quota for every provider credential
-        // the account holds (Google OAuth pools + Ollama usage pools).
-        const providerIds = new Set<string>(
-          (account.config.credentials ?? []).map((c) => c.provider),
-        );
-        if (providerIds.size === 0) providerIds.add(primaryProviderId(account.config));
-        for (const pid of providerIds) {
-          try {
-            await this.ensureValidTokenForProvider(account, pid);
-            await getProviderAdapter(pid).fetchQuota(account, quotaCtx);
-            quotaPublished = true;
-          } catch {
-            // One invalid provider credential must not suppress sibling pools.
-          }
-        }
-      } catch {
-        // Token refresh or quota fetch failed, skip this account
+      if (await this.pollAccountQuota(account)) {
+        quotaPublished = true;
       }
 
-      // Consolidated RAW POLL across all providers on this account:
-      // google first (Antigravity OAuth pools), then ollama (usage pools).
-      this.logConsolidatedPoll(account);
-
-      // Auto-warmup: send minimal kickstart requests for idle pools on accounts that have opted
-      // in via allowFreshWindowStartsOverride, but only if the operator has enabled the global
-      // auto-warmup toggle. "Idle" includes both fresh pools (no active timer) and rolling idle
-      // pools (100% quota with resetTime very close to a full 5h or 7d window — timer exists but
-      // untouched). Deduplicates by upstream model within this cycle.
+      // Auto-warmup reuses the bulk path so all successful kickstarts are
+      // followed by one account-level quota refresh, not one refresh per pool.
       if (this.autoWarmupEnabled && account.allowFreshWindowStartsOverride) {
-        const idlePools = account.quota.filter(
-          (q) =>
-            this.isQuotaIdleForKickstart(q) &&
-            this.getKickstartTarget(account, q.modelKey) !== null,
-        );
-        if (idlePools.length > 0) {
-          const alreadySent =
-            this.warmupSentThisCycle.get(account.config.email) ?? new Set<string>();
-          const upstreamToQuotaKey = new Map<string, string>();
-          for (const q of idlePools) {
-            const target = this.getKickstartTarget(account, q.modelKey);
-            if (!target) continue;
-            const upstream = target.upstreamModel;
-            if (!upstreamToQuotaKey.has(upstream)) {
-              upstreamToQuotaKey.set(upstream, q.modelKey);
-            }
+        try {
+          const warmup = await this.kickstartAllFreshTimers(account.config.email);
+          if (warmup.results.some((result) => result.ok)) {
+            quotaPublished = true;
           }
-          for (const [upstream, quotaKey] of upstreamToQuotaKey) {
-            if (!alreadySent.has(upstream)) {
-              alreadySent.add(upstream);
-              // Fire-and-forget — errors are handled internally by kickstartTimerForAccount
-              void this.kickstartTimerForAccount(account.config.email, quotaKey).catch(
-                () => {},
-              );
-            }
-          }
-          this.warmupSentThisCycle.set(account.config.email, alreadySent);
+        } catch {
+          // Warmup is opportunistic and must not abort the polling cycle.
         }
       }
     }
@@ -975,17 +1001,10 @@ export class AccountRotator {
     return q?.timerType ?? "fresh";
   }
 
-  // A pool is "idle for kickstart" when it has a fresh pool (no active timer)
-  // OR a rolling idle timer (100% quota with resetTime very close to a full 5h or 7d
-  // window — the timer exists but the quota is completely untouched). Sending a
-  // minimal kickstart request against an idle pool starts the consumption clock.
+  // A pool is "idle for kickstart" when it has a fresh pool (no active timer).
+  // Sending a minimal kickstart request against an idle pool starts the consumption clock.
   private isQuotaIdleForKickstart(q: ModelQuota): boolean {
-    if (q.timerType === "fresh") return true;
-    if (!q.resetTime || q.percentRemaining !== 100) return false;
-    const remaining = new Date(q.resetTime).getTime() - Date.now();
-    if (remaining <= 0) return false;
-    const within = (target: number) => Math.abs(remaining - target) < 600_000;
-    return within(5 * 3600 * 1000) || within(7 * 24 * 3600 * 1000);
+    return q.timerType === "fresh";
   }
 
   /**
@@ -996,22 +1015,28 @@ export class AccountRotator {
   private getKickstartTarget(
     account: AccountRuntime,
     quotaModelKey: string,
-  ): { providerId: string; adapter: ReturnType<typeof getProviderAdapter>; upstreamModel: string } | null {
-    const quota = account.quota.find((candidate) => candidate.modelKey === quotaModelKey);
+  ): {
+    poolKey: string;
+    providerId: string;
+    adapter: ReturnType<typeof getProviderAdapter>;
+    upstreamModel: string;
+  } | null {
+    const poolKey = this.resolveAccountPoolKey(account, quotaModelKey);
+    const quota = account.quota.find((candidate) => candidate.modelKey === poolKey);
     const providerId =
       quota?.providerId ??
-      (quotaModelKey === "session"
+      (poolKey === "session"
         ? "ollama"
-        : quotaModelKey === CODEX_QUOTA_MODEL_KEY ||
-            quotaModelKey.startsWith(`${CODEX_QUOTA_MODEL_KEY}:`)
+        : poolKey === CODEX_QUOTA_MODEL_KEY ||
+            poolKey.startsWith(`${CODEX_QUOTA_MODEL_KEY}:`)
           ? "openai-codex"
           : DEFAULT_PROVIDER);
     if (!hasCredential(account.config, providerId)) return null;
 
     const adapter = getProviderAdapter(providerId);
-    const upstreamModel = adapter.getKickstartModelForPool(quotaModelKey);
+    const upstreamModel = adapter.getKickstartModelForPool(poolKey);
     if (!upstreamModel) return null;
-    return { providerId, adapter, upstreamModel };
+    return { poolKey, providerId, adapter, upstreamModel };
   }
 
   // Timer priority for a specific model:
@@ -1344,13 +1369,25 @@ export class AccountRotator {
     now: number,
     activeForModels: string[],
   ): AccountStatus["status"] {
-    const inCooldownModels = Object.values(account.cooldownsByModel).filter(
-      (ts) => ts > now,
-    );
+    const defaultCooldownActive =
+      (account.cooldownsByModel.__default__ ?? 0) > now;
+    const knownPools = new Set(account.quota.map((quota) => quota.modelKey));
+    for (const [modelKey, cooldownUntil] of Object.entries(
+      account.cooldownsByModel,
+    )) {
+      if (modelKey !== "__default__" && cooldownUntil > now) {
+        knownPools.add(modelKey);
+      }
+    }
+    const allKnownPoolsCooling =
+      knownPools.size > 0 &&
+      [...knownPools].every(
+        (modelKey) => (account.cooldownsByModel[modelKey] ?? 0) > now,
+      );
     if (account.flagged) return "flagged";
     if (account.disabled) return "disabled";
     if (account.consecutiveErrors > 0 && !account.disabled) return "error";
-    if (inCooldownModels.length > 0) return "cooldown";
+    if (defaultCooldownActive || allKnownPoolsCooling) return "cooldown";
     if (this.isDailySafetyStopped(account, now)) return "exhausted";
     if (activeForModels.length > 0) return "active";
     return "ready";
@@ -2883,7 +2920,7 @@ export class AccountRotator {
   ): void {
     const now = Date.now();
     const modelKey = model
-      ? (this.resolvePoolKeyForModel(model) ?? resolveQuotaModelKey(model) ?? "__default__")
+      ? this.resolveAccountPoolKey(account, model)
       : "__default__";
     if (model && (modelKey.startsWith(`${CODEX_QUOTA_MODEL_KEY}:`) || isCodexRequestModel(model))) {
       this.setProviderCooldown(account, "openai-codex", cooldownMs);
@@ -2910,7 +2947,7 @@ export class AccountRotator {
       this.setProviderCooldown(account, "openai-codex", cooldownMs);
       return;
     }
-    const poolKey = model ? this.resolvePoolKeyForModel(model) : null;
+    const poolKey = model ? this.resolveAccountPoolKey(account, model) : null;
     const isAccountScopedProvider =
       providerResourceExhausted ||
       (poolKey && (poolKey.startsWith("opencode-zen") || poolKey.startsWith("session")));
@@ -2923,7 +2960,7 @@ export class AccountRotator {
       return;
     }
     const modelKey = model
-      ? (this.resolvePoolKeyForModel(model) ?? resolveQuotaModelKey(model) ?? "__default__")
+      ? this.resolveAccountPoolKey(account, model)
       : "__default__";
     const windowMs =
       this.config.projectCircuitBreakerWindowMs ?? 10 * 60 * 1000;
@@ -3507,6 +3544,21 @@ export class AccountRotator {
       return "session";
     }
     return key;
+  }
+
+  /** Resolve upstream models and already-published quota keys to one account pool. */
+  private resolveAccountPoolKey(account: AccountRuntime, key: string): string {
+    const kickstartPool = QUOTA_POOL_FOR_KICKSTART_MODEL[key];
+    if (kickstartPool) return this.resolvePoolKey(account, kickstartPool);
+    if (
+      Object.values(QUOTA_POOL_FOR_KICKSTART_MODEL).includes(key) ||
+      account.quota.some((quota) => quota.modelKey === key) ||
+      getProviderIdForPoolKey(key) !== DEFAULT_PROVIDER
+    ) {
+      return this.resolvePoolKey(account, key);
+    }
+    const modelPool = this.resolvePoolKeyForModel(key) ?? resolveQuotaModelKey(key);
+    return this.resolvePoolKey(account, modelPool ?? "__default__");
   }
 
   private isRoutableForModel(
@@ -4246,6 +4298,7 @@ export class AccountRotator {
   async kickstartTimerForAccount(
     email: string,
     quotaModelKey: string,
+    refreshQuota = true,
   ): Promise<{ ok: boolean; status: number; upstreamModel: string; error?: string }> {
     const account = this.accounts.find((a) => a.config.email === email);
     if (!account) {
@@ -4288,6 +4341,7 @@ export class AccountRotator {
     }
 
     const upstreamModel = target.upstreamModel;
+    const poolKey = target.poolKey;
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);
@@ -4320,7 +4374,7 @@ export class AccountRotator {
       clearTimeout(timeout);
     } else {
       const body = JSON.stringify({
-        project: this.getProjectIdForModel(account, quotaModelKey),
+        project: this.getProjectIdForModel(account, poolKey),
         model: upstreamModel,
         request: {
           contents: [{ role: "user", parts: [{ text: "." }] }],
@@ -4354,21 +4408,49 @@ export class AccountRotator {
       clearTimeout(timeout);
     }
 
-    // Consume and discard the response body to free the connection
-    try {
-      await response.body?.cancel();
-    } catch {
-      // ignore
+    let errorText = "";
+    if (response.status === 429) {
+      errorText = await response.text().catch(() => "");
+    } else {
+      // Consume and discard the response body to free the connection.
+      try {
+        await response.body?.cancel();
+      } catch {
+        // ignore
+      }
     }
 
     const label = account.config.label || account.config.email;
 
     if (response.status === 429) {
-      const cooldownMs = 60_000;
-      this.markExhausted(account, quotaModelKey, cooldownMs, "kickstart 429");
-      this.recordProvider429(account, quotaModelKey, cooldownMs);
+      const providerResourceExhausted =
+        classifyRateLimitReason(errorText, response.status) === "quota-exhausted";
+      const cooldownMs = providerResourceExhausted
+        ? target.providerId === DEFAULT_PROVIDER
+          ? parseRetryAfterMs(
+              errorText,
+              response.headers,
+              RESOURCE_EXHAUSTED_FALLBACK_MS,
+            )
+          : RESOURCE_EXHAUSTED_FALLBACK_MS
+        : Math.min(
+            parseRetryAfterMs(errorText, response.headers),
+            RESOURCE_EXHAUSTED_FALLBACK_MS,
+          );
+      this.markExhausted(
+        account,
+        poolKey,
+        cooldownMs,
+        errorText || "kickstart 429",
+      );
+      this.recordProvider429(
+        account,
+        poolKey,
+        cooldownMs,
+        providerResourceExhausted,
+      );
       this.log(
-        `${label} [${quotaModelKey}]: kickstart 429 — cooldown ${cooldownMs / 1000}s`,
+        `${label} [${poolKey}]: kickstart 429 — cooldown ${cooldownMs / 1000}s`,
         "warn",
       );
       return { ok: false, status: 429, upstreamModel };
@@ -4389,20 +4471,28 @@ export class AccountRotator {
     }
 
     if (response.ok) {
-      this.recordRequest(account, quotaModelKey);
+      this.recordRequest(account, poolKey);
       this.log(
-        `${label} [${quotaModelKey}]: kickstart sent via ${upstreamModel} — timer should start within the next quota poll`,
+        `${label} [${poolKey}]: kickstart sent via ${upstreamModel} — ${refreshQuota ? "refreshing quota" : "bulk quota refresh pending"}`,
       );
+      // Immediately re-poll the account quota so newly started resetTime and timerType
+      // are captured and exposed without waiting for the background polling cycle.
+      if (refreshQuota) {
+        try {
+          await this.pollAccountQuota(account);
+        } catch {
+          // non-fatal
+        }
+      }
     }
 
     return { ok: response.ok, status: response.status, upstreamModel };
   }
 
   /**
-   * Kickstart all quota pools that are currently idle (no active timer, or rolling
-   * idle with 100% quota and a fresh resetTime) for a given account. Deduplicates by
-   * upstream model so that pools sharing the same upstream (e.g. gemini-3.5-flash and
-   * gemini-3.1-pro → gemini-3-flash) only receive one request.
+   * Kickstart all quota pools that are currently idle (no active timer)
+   * for a given account. Deduplicates by upstream model so that pools
+   * sharing the same upstream only receive one request.
    */
   async kickstartAllFreshTimers(email: string): Promise<{
     ok: boolean;
@@ -4450,8 +4540,20 @@ export class AccountRotator {
       // Use the primary quota pool key for this upstream (for recordRequest/markExhausted)
       const primaryQuotaKey =
         QUOTA_POOL_FOR_KICKSTART_MODEL[upstreamModel] ?? quotaPools[0];
-      const result = await this.kickstartTimerForAccount(email, primaryQuotaKey);
+      const result = await this.kickstartTimerForAccount(
+        email,
+        primaryQuotaKey,
+        false,
+      );
       results.push({ quotaPools, upstreamModel, ok: result.ok, status: result.status });
+    }
+
+    if (results.some((result) => result.ok)) {
+      try {
+        await this.pollAccountQuota(account);
+      } catch {
+        // A failed refresh must not rewrite successful kickstart results.
+      }
     }
 
     const allOk = results.every((r) => r.ok);

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -25,29 +25,23 @@ function timerDisplayLabel(timerType) {
   return timerType === "fresh" ? "idle" : timerType;
 }
 
-// A pool is "idle" (worth kickstarting) when either:
-//   1. The server reports timerType === "fresh" (no active timer at all), or
-//   2. Google is showing a "rolling" timer: 100% quota AND remaining time is
-//      very close to a full 5h or 7d window (the timer exists but hasn't been
-//      touched yet — a kickstart request will start consuming from it).
-function isIdleForKickstart(q, now) {
-  if (q.timerType === "fresh") return true;
-  if (!q.resetTime || q.percentRemaining !== 100) return false;
-  var remaining = new Date(q.resetTime).getTime() - now;
-  if (remaining <= 0) return false;
-  var isRolling5h = Math.abs(remaining - 5 * 3600000) < 600000;
-  var isRolling7d = Math.abs(remaining - 7 * 86400000) < 600000;
-  return isRolling5h || isRolling7d;
+// A pool is "idle" (worth kickstarting) when it has no active timer running (fresh).
+function isIdleForKickstart(q) {
+  return q.timerType === "fresh";
 }
 
 function isKickstartSupported(q) {
   if (!q) return false;
-  if (q.providerId === "openai-codex") return false;
+  if (q.providerId === "openai-codex" || q.providerId === "opencode-zen") return false;
+  if (q.providerId === "ollama" && q.modelKey !== "session") return false;
   var key = String(q.modelKey || "");
   return (
     key !== "openai-codex" &&
     key !== "openai-codex-spark" &&
-    key.indexOf("openai-codex:") !== 0
+    key.indexOf("openai-codex:") !== 0 &&
+    key !== "opencode-zen" &&
+    key.indexOf("opencode-zen:") !== 0 &&
+    key !== "weekly"
   );
 }
 
@@ -76,32 +70,44 @@ function renderQuotaBars(account) {
   var sortedQuota = quota.slice().sort(function (a, b) {
     return getQuotaItemProviderRank(a) - getQuotaItemProviderRank(b);
   });
-  var now = Date.now();
+  var accountInactive = account.status === "disabled" || account.status === "flagged";
   var rows = sortedQuota
     .map(function (q) {
       var inFlightForModel = (account.inFlightByModel || {})[q.modelKey] || 0;
-      var clearButton =
-        inFlightForModel > 0
-          ? '<button class="btn-clear-flight" title="Clear in-flight counter for ' +
-            escapeHtml(q.displayName) +
-            '" onclick="clearInFlight(\'' +
-            jsString(account.email) +
-            "', '" +
-            jsString(q.modelKey) +
-            "')\">" +
-            "Clear</button>"
-          : '<button class="btn-clear-flight" title="No in-flight requests for ' +
-            escapeHtml(q.displayName) +
-            '" disabled>Clear</button>';
-      var idle = isKickstartSupported(q) && isIdleForKickstart(q, now);
-      var kickstartBtn = "";
+      var idle =
+        !accountInactive && isKickstartSupported(q) && isIdleForKickstart(q);
+      var actionButton = "";
+      if (inFlightForModel > 0) {
+        actionButton =
+          '<button class="btn-clear-flight" title="Clear in-flight counter for ' +
+          escapeHtml(q.displayName) +
+          '" onclick="clearInFlight(\'' +
+          jsString(account.email) +
+          "', '" +
+          jsString(q.modelKey) +
+          "')\">" +
+          "Clear</button>";
+      } else if (idle) {
+        actionButton =
+          '<button class="btn-clear-flight" title="Send minimal request to start idle timer for ' +
+          escapeHtml(q.displayName) +
+          '" onclick="kickstartTimer(\'' +
+          jsString(account.email) +
+          "', '" +
+          jsString(q.modelKey) +
+          "')\">▶ Start</button>";
+      } else {
+        actionButton =
+          '<button class="btn-clear-flight" title="No in-flight requests for ' +
+          escapeHtml(q.displayName) +
+          '" disabled>Clear</button>';
+      }
       var color = quotaBarColor(q.percentRemaining);
       var timerClass = "timer-" + q.timerType;
       var resetLabel = "";
-      if (idle && q.resetTime && q.timerType !== "fresh") {
-        // Rolling idle timer already has resetTime set; show "idle" label
+      if (q.timerType === "fresh") {
         resetLabel = '<span style="color:var(--text-dim)">idle</span>';
-      } else if (q.resetTime && q.timerType !== "fresh") {
+      } else if (q.resetTime) {
         var remaining = new Date(q.resetTime).getTime() - Date.now();
         if (remaining > 0) {
           resetLabel = formatDuration(remaining);
@@ -126,8 +132,7 @@ function renderQuotaBars(account) {
         (resetLabel || "--") +
         "</span>" +
         '<span class="quota-action">' +
-        clearButton +
-        kickstartBtn +
+        actionButton +
         "</span>" +
         "</div>"
       );
@@ -494,8 +499,10 @@ function renderAccounts(data) {
           ? "Use Global Fresh Policy"
           : "Allow Fresh On This Account") +
         "</button>" +
-        ((a.quota || []).some(function (q) {
-          return isKickstartSupported(q) && isIdleForKickstart(q, Date.now());
+        (a.status !== "disabled" &&
+        a.status !== "flagged" &&
+        (a.quota || []).some(function (q) {
+          return isKickstartSupported(q) && isIdleForKickstart(q);
         })
           ? '<button class="btn-enable" onclick="kickstartAllTimers(\'' +
             jsString(a.email) +
@@ -2809,6 +2816,16 @@ async function kickstartAllTimers(email) {
     alert("Kickstart failed: " + data.error);
   } else if (data.results && data.results.length === 0) {
     alert("No idle timers found for this account.");
+  } else if (!data.ok) {
+    var failed = (data.results || []).filter(function (r) {
+      return !r.ok;
+    });
+    var details = failed
+      .map(function (r) {
+        return r.upstreamModel + " (status " + r.status + ")";
+      })
+      .join(", ");
+    alert("Kickstart partially failed: " + (details || "unknown error"));
   }
   refresh();
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -882,6 +882,8 @@ export const ANTIGRAVITY_ENDPOINTS = [
 // used for kickstart warmup requests. Gemini 3.6/3.5 Flash and Gemini 3.1 Pro
 // share the same upstream pool, so all map to gemini-3-flash.
 export const KICKSTART_MODEL_FOR_QUOTA_POOL: Record<string, string> = {
+  claude: "gpt-oss-120b-medium",
+  gemini: "gemini-3-flash",
   "claude-opus-4-6-thinking": "gpt-oss-120b-medium",
   "gemini-3.5-flash": "gemini-3-flash",
   "gemini-3.6-flash": "gemini-3-flash",

--- a/src/types.ts
+++ b/src/types.ts
@@ -879,13 +879,11 @@ export const ANTIGRAVITY_ENDPOINTS = [
 ] as const;
 
 // Maps each quota pool key (Google quota API) to the cheapest upstream model
-// used for kickstart warmup requests. Gemini 3.6/3.5 Flash and Gemini 3.1 Pro
-// share the same upstream pool, so all map to gemini-3-flash.
+// used for kickstart warmup requests. The pool key is the canonical family key
+// from QUOTA_MODEL_KEYS (i.e. "claude" or "gemini"), not an altKey/request model name.
 export const KICKSTART_MODEL_FOR_QUOTA_POOL: Record<string, string> = {
-  "claude-opus-4-6-thinking": "gpt-oss-120b-medium",
-  "gemini-3.5-flash": "gemini-3-flash",
-  "gemini-3.6-flash": "gemini-3-flash",
-  "gemini-3.1-pro": "gemini-3-flash",
+  "claude": "gpt-oss-120b-medium",
+  "gemini": "gemini-3-flash",
 };
 
 export const QUOTA_API_URL =

--- a/test/compression-orchestrator.test.ts
+++ b/test/compression-orchestrator.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
 import {
   applyPromptCompression,
   parseCompressionMode,
@@ -7,6 +8,17 @@ import {
 import type { ChatMessage } from "../src/providers/google-antigravity/translators.js";
 
 describe("Compression Orchestrator", () => {
+  it("keeps the OpenCode compression header in Advanced settings only", () => {
+    const guide = readFileSync(
+      new URL("../docs/integrations/opencode.md", import.meta.url),
+      "utf8",
+    );
+    const advanced = guide.indexOf("## Advanced Settings & Prompt Compression");
+    assert.ok(advanced > 0);
+    assert.doesNotMatch(guide.slice(0, advanced), /X-Rotator-Compression/);
+    assert.match(guide.slice(advanced), /X-Rotator-Compression/);
+  });
+
   it("parses compression modes from headers and config", () => {
     assert.equal(parseCompressionMode("lite"), "lite");
     assert.equal(parseCompressionMode("rtk"), "rtk");

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -185,6 +185,78 @@ describe("dashboard", () => {
     );
   });
 
+  it("does not render kickstart actions for disabled or flagged accounts", () => {
+    for (const status of ["disabled", "flagged"]) {
+      const html = renderAccountCards(
+        [
+          {
+            ...accountCardFixture(0),
+            status,
+            quota: [
+              {
+                modelKey: "claude",
+                displayName: "Claude",
+                providerId: "google-antigravity",
+                percentRemaining: 100,
+                resetTime: null,
+                timerType: "fresh",
+              },
+            ],
+          },
+        ],
+        5,
+      );
+
+      assert.doesNotMatch(html, />▶ Start</);
+      assert.doesNotMatch(html, />Start Idle Timers</);
+    }
+
+    const ready = renderAccountCards(
+      [
+        {
+          ...accountCardFixture(0),
+          quota: [
+            {
+              modelKey: "claude",
+              displayName: "Claude",
+              providerId: "google-antigravity",
+              percentRemaining: 100,
+              resetTime: null,
+              timerType: "fresh",
+            },
+          ],
+        },
+      ],
+      5,
+    );
+    assert.match(ready, />▶ Start</);
+    assert.match(ready, />Start Idle Timers</);
+  });
+
+  it("renders an unknown non-fresh reset as -- instead of idle", () => {
+    const html = renderAccountCards(
+      [
+        {
+          ...accountCardFixture(0),
+          quota: [
+            {
+              modelKey: "gemini",
+              displayName: "Gemini",
+              providerId: "google-antigravity",
+              percentRemaining: 50,
+              resetTime: null,
+              timerType: "5h",
+            },
+          ],
+        },
+      ],
+      5,
+    );
+
+    assert.match(html, /<span class="quota-reset">--<\/span>/);
+    assert.doesNotMatch(html, /<span class="quota-reset"><span[^>]*>idle<\/span><\/span>/);
+  });
+
   it("assigns distinct family colors for token graph (Claude: Red, Gemini: Blue, Ollama: Green)", () => {
     const js = readDashboardJs();
     const sandbox: Record<string, unknown> = {
@@ -431,10 +503,13 @@ describe("dashboard", () => {
     };
     const script = new Script(
       js +
-        "\nthis.isKickstartSupported = isKickstartSupported;",
+        "\nthis.isKickstartSupported = isKickstartSupported;\nthis.isIdleForKickstart = isIdleForKickstart;",
     );
     script.runInNewContext(sandbox);
     const isKickstartSupported = sandbox.isKickstartSupported as (
+      quota: Record<string, unknown>,
+    ) => boolean;
+    const isIdleForKickstart = sandbox.isIdleForKickstart as (
       quota: Record<string, unknown>,
     ) => boolean;
 
@@ -443,8 +518,32 @@ describe("dashboard", () => {
       false,
     );
     assert.equal(
+      isKickstartSupported({ modelKey: "opencode-zen", providerId: "opencode-zen" }),
+      false,
+    );
+    assert.equal(
       isKickstartSupported({ modelKey: "session", providerId: "ollama" }),
       true,
+    );
+    assert.equal(
+      isKickstartSupported({ modelKey: "weekly", providerId: "ollama" }),
+      false,
+    );
+    assert.equal(
+      isKickstartSupported({ modelKey: "gemini", providerId: "google-antigravity" }),
+      true,
+    );
+    assert.equal(
+      isIdleForKickstart({ timerType: "fresh" }),
+      true,
+    );
+    assert.equal(
+      isIdleForKickstart({
+        timerType: "5h",
+        resetTime: new Date(Date.now() + 60_000).toISOString(),
+        percentRemaining: 100,
+      }),
+      false,
     );
   });
 

--- a/test/model-resolution.test.ts
+++ b/test/model-resolution.test.ts
@@ -181,6 +181,62 @@ describe("model resolution", () => {
 		assert.equal(quotas.length, 1);
 	});
 
+	it("treats intact Google quota as fresh even when reset times are present", () => {
+		const fiveHoursFromNow = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+		const sevenDaysFromNow = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+		const oldQuota = [
+			{
+				modelKey: "claude",
+				displayName: "Claude",
+				percentRemaining: 100,
+				resetTime: fiveHoursFromNow,
+				timerType: "5h" as const,
+			},
+			{
+				modelKey: "gemini",
+				displayName: "Gemini",
+				percentRemaining: 100,
+				resetTime: sevenDaysFromNow,
+				timerType: "7d" as const,
+			},
+		];
+		const quotas = extractQuotas(
+			{
+				models: {
+					claude: {
+						quotaInfo: { remainingFraction: 1, resetTime: fiveHoursFromNow },
+					},
+					gemini: {
+						quotaInfo: { remainingFraction: 1, resetTime: sevenDaysFromNow },
+					},
+				},
+			},
+			oldQuota,
+		);
+
+		for (const quota of quotas) {
+			assert.equal(quota.timerType, "fresh");
+			assert.equal(quota.resetTime, null);
+		}
+
+		const [partiallyUsed] = extractQuotas(
+			{
+				models: {
+					claude: {
+						quotaInfo: {
+							remainingFraction: 0.999,
+							resetTime: fiveHoursFromNow,
+						},
+					},
+				},
+			},
+			[],
+		);
+		assert.equal(partiallyUsed.percentRemaining, 100);
+		assert.equal(partiallyUsed.timerType, "5h");
+		assert.equal(partiallyUsed.resetTime, fiveHoursFromNow);
+	});
+
 it("orders quota model keys: claude, gemini", () => {
 		const orderedKeys = Object.keys(QUOTA_MODEL_KEYS);
 		assert.deepEqual(orderedKeys, ["claude", "gemini"]);

--- a/test/proxy-compat.test.ts
+++ b/test/proxy-compat.test.ts
@@ -306,19 +306,51 @@ describe("classifyUpstreamResponse", () => {
 		return new Response(bodyText, { status, headers: { "content-type": "text/plain" } });
 	}
 
-	it("classifies 429 with RESOURCE_EXHAUSTED as providerResourceExhausted", async () => {
+	it("uses the complete Antigravity RESOURCE_EXHAUSTED reset duration", async () => {
+		const action = await classifyUpstreamResponse(
+			response(429, `{"error":{"status":"RESOURCE_EXHAUSTED","message":"quota exceeded. Resets in 1h20m14s"}}`),
+			"https://api.example.com",
+			fakeAccount,
+			"gemini-3.1-pro",
+			fakeModelKey,
+			"google-antigravity",
+		);
+		assert.equal(action.kind, "rate-limited");
+		if (action.kind === "rate-limited") {
+			assert.equal(action.providerResourceExhausted, true);
+			assert.equal(action.cooldownMs, 4_815_000);
+			assert.match(action.errorText, /quota exceeded/);
+		}
+	});
+
+	it("uses the 30 minute Antigravity fallback without a parseable reset", async () => {
 		const action = await classifyUpstreamResponse(
 			response(429, `{"error":{"status":"RESOURCE_EXHAUSTED","message":"quota exceeded"}}`),
 			"https://api.example.com",
 			fakeAccount,
 			"gemini-3.1-pro",
 			fakeModelKey,
+			"google-antigravity",
 		);
 		assert.equal(action.kind, "rate-limited");
 		if (action.kind === "rate-limited") {
 			assert.equal(action.providerResourceExhausted, true);
-			assert.ok(action.cooldownMs > 0);
-			assert.match(action.errorText, /quota exceeded/);
+			assert.equal(action.cooldownMs, 1_800_000);
+		}
+	});
+
+	it("keeps RESOURCE_EXHAUSTED reset-duration semantics scoped to Antigravity", async () => {
+		const action = await classifyUpstreamResponse(
+			response(429, `{"error":{"status":"RESOURCE_EXHAUSTED","message":"Resets in 1h20m14s"}}`),
+			"https://api.example.com",
+			fakeAccount,
+			"gpt-oss:20b",
+			"session",
+			"ollama",
+		);
+		assert.equal(action.kind, "rate-limited");
+		if (action.kind === "rate-limited") {
+			assert.equal(action.cooldownMs, 1_800_000);
 		}
 	});
 

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -68,6 +68,7 @@ function makeAccount(email: string, projectId = "test-project"): AccountRuntime 
 
 type RotatorTracking = {
 	markExhausted?: number;
+	lastMarkExhausted?: { model: string | undefined; cooldownMs: number };
 	markFlagged?: number;
 	markError?: number;
 	recordRequest?: number;
@@ -107,7 +108,14 @@ function makeRotator(
 		finishRequest: () => { tracking.finishRequest!++; },
 		getSafetyJitterMs: () => 0,
 		recordUpstreamAttempt: () => {},
-		markExhausted: () => { tracking.markExhausted!++; },
+		markExhausted: (
+			_account: AccountRuntime,
+			model: string | undefined,
+			cooldownMs: number,
+		) => {
+			tracking.markExhausted!++;
+			tracking.lastMarkExhausted = { model, cooldownMs };
+		},
 		recordProvider429: () => { tracking.recordProvider429!++; },
 		getFlagContext: () => ({
 			timerType: "fresh",
@@ -379,7 +387,11 @@ describe("proxy e2e: 429 rate-limited", () => {
 		});
 		endpointOverrides.splice(0, endpointOverrides.length, upstream.url);
 
-		const tracking = { markExhausted: 0, recordProvider429: 0, finishRequest: 0 };
+		const tracking: RotatorTracking = {
+			markExhausted: 0,
+			recordProvider429: 0,
+			finishRequest: 0,
+		};
 		const rotator = makeRotator(makeAccount("rl@example.com"), tracking);
 
 		try {
@@ -406,16 +418,20 @@ describe("proxy e2e: 429 rate-limited", () => {
 		}
 	});
 
-	it("uses RESOURCE_EXHAUSTED cooldown (30min) for quota-exhausted responses", async () => {
+	it("uses the full provider reset duration for RESOURCE_EXHAUSTED", async () => {
 		const upstream = await listen((req, res) => {
 			res.writeHead(429, {
 				"Content-Type": "application/json",
 			});
-			res.end(JSON.stringify({ error: { status: "RESOURCE_EXHAUSTED", message: "quota exceeded" } }));
+			res.end(JSON.stringify({ error: { status: "RESOURCE_EXHAUSTED", message: "quota exceeded. Resets in 1h20m14s" } }));
 		});
 		endpointOverrides.splice(0, endpointOverrides.length, upstream.url);
 
-		const tracking = { markExhausted: 0, recordProvider429: 0, finishRequest: 0 };
+		const tracking: RotatorTracking = {
+			markExhausted: 0,
+			recordProvider429: 0,
+			finishRequest: 0,
+		};
 		const rotator = makeRotator(makeAccount("quota@example.com"), tracking);
 
 		try {
@@ -430,10 +446,51 @@ describe("proxy e2e: 429 rate-limited", () => {
 			assert.equal(outcome.ok, false);
 			if (!outcome.ok) {
 				assert.equal(outcome.status, 429);
-				// RESOURCE_EXHAUSTED gets a fixed 30min cooldown regardless of Retry-After
-				assert.equal(outcome.retryAfterMs, 1_800_000);
+				assert.equal(outcome.retryAfterMs, 4_815_000);
 			}
 			assert.equal(tracking.finishRequest, 1, "RESOURCE_EXHAUSTED should release the account once");
+			assert.deepEqual(tracking.lastMarkExhausted, {
+				model: "gemini-3.1-pro",
+				cooldownMs: 4_815_000,
+			});
+		} finally {
+			await upstream.close();
+		}
+	});
+
+	it("falls back to 30 minutes for RESOURCE_EXHAUSTED without a reset duration", async () => {
+		const upstream = await listen((_req, res) => {
+			res.writeHead(429, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ error: { status: "RESOURCE_EXHAUSTED", message: "quota exceeded" } }));
+		});
+		endpointOverrides.splice(0, endpointOverrides.length, upstream.url);
+
+		const tracking: RotatorTracking = {
+			markExhausted: 0,
+			recordProvider429: 0,
+			finishRequest: 0,
+		};
+		const rotator = makeRotator(makeAccount("quota-fallback@example.com"), tracking);
+
+		try {
+			const outcome = await withRotation(
+				rotator,
+				"gemini-3.1-pro",
+				{},
+				makeBody(),
+				async () => "should-not-reach",
+			);
+
+			assert.equal(outcome.ok, false);
+			if (!outcome.ok) {
+				assert.equal(outcome.status, 429);
+				assert.equal(outcome.retryAfterMs, 1_800_000);
+			}
+			assert.equal(tracking.finishRequest, 1);
+			assert.deepEqual(tracking.lastMarkExhausted, {
+				model: "gemini-3.1-pro",
+				cooldownMs: 1_800_000,
+			});
 		} finally {
 			await upstream.close();
 		}

--- a/test/rate-limit-parser.test.ts
+++ b/test/rate-limit-parser.test.ts
@@ -25,9 +25,19 @@ describe("rate limit parser", () => {
 		assert.equal(ms, 46000);
 	});
 
+	it("parses the full Antigravity reset duration", () => {
+		const ms = parseRetryAfterMs("RESOURCE_EXHAUSTED. Resets in 1h20m14s", new Headers());
+		assert.equal(ms, 4_815_000);
+	});
+
 	it("falls back to the default retry window", () => {
 		const ms = parseRetryAfterMs("unstructured error", new Headers());
 		assert.equal(ms, 60000);
+	});
+
+	it("accepts the caller's configured fallback when no reset is parseable", () => {
+		const ms = parseRetryAfterMs("unstructured error", new Headers(), 1_800_000);
+		assert.equal(ms, 1_800_000);
 	});
 
 	it("classifies quota exhaustion and capacity distinctly", () => {

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -28,6 +28,7 @@ let AccountRotator: typeof import("../src/rotator.js").AccountRotator;
 let initDb: typeof import("../src/db-store.js").initDb;
 let closeDb: typeof import("../src/db-store.js").closeDb;
 let isDbConfigured: typeof import("../src/db-store.js").isDbConfigured;
+let setCachedState: typeof import("../src/db-store.js").setCachedState;
 let getAccountsPath: typeof import("../src/paths.js").getAccountsPath;
 let getProviderAdapter: typeof import("../src/providers/registry.js").getProviderAdapter;
 type AccountRuntime = import("../src/types.js").AccountRuntime;
@@ -41,6 +42,7 @@ before(async () => {
   initDb = dbStore.initDb;
   closeDb = dbStore.closeDb;
   isDbConfigured = dbStore.isDbConfigured;
+  setCachedState = dbStore.setCachedState;
   AccountRotator = rotatorMod.AccountRotator;
   getAccountsPath = pathsMod.getAccountsPath;
   getProviderAdapter = regMod.getProviderAdapter;
@@ -119,6 +121,111 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
   it("hostile database environment variables do not select external database backend", () => {
     // Assert db-store is not connected to PostgreSQL
     assert.equal(isDbConfigured(), false, "isDbConfigured must be false when DB URL is not set");
+  });
+
+  it("cools only the exhausted Antigravity pool and keeps its sibling routable", async () => {
+    const account = makeAccount("pool-isolation@example.com", "pool-project", "claude", 100);
+    account.quota = [
+      account.quota[0],
+      {
+        modelKey: "gemini",
+        displayName: "Gemini",
+        providerId: "google-antigravity",
+        percentRemaining: 100,
+        resetTime: null,
+        timerType: "fresh",
+      },
+    ];
+    const rotator = new AccountRotator({
+      proxyPort: 51223,
+      rotateOnQuotaDrop: 20,
+      routingPolicy: "timer-first",
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts: [account.config],
+    });
+    rotator.stopQuotaPolling();
+    (rotator as any).accounts = [account];
+
+    const before = Date.now();
+    rotator.markExhausted(
+      account,
+      "claude-sonnet-4-6",
+      4_815_000,
+      "RESOURCE_EXHAUSTED",
+    );
+
+    assert.ok((account.cooldownsByModel.claude ?? 0) >= before + 4_815_000);
+    assert.equal(account.cooldownsByModel.gemini, undefined);
+    assert.equal(account.cooldownsByModel.__default__, undefined);
+    assert.equal(account.providerCooldowns?.["google-antigravity"], undefined);
+
+    const sibling = await rotator.getActiveAccount("gemini-3.1-pro");
+    assert.equal(sibling, account, "Gemini must remain routable while Claude cools down");
+    rotator.finishRequest(sibling!, "gemini");
+
+    const uiAccount = rotator
+      .getStatus()
+      .accounts.find((candidate) => candidate.email === account.config.email);
+    assert.notEqual(uiAccount?.status, "cooldown", "one cooled pool is not a global account cooldown");
+
+    rotator.markExhausted(account, "gemini-3.1-pro", 4_815_000, "RESOURCE_EXHAUSTED");
+    const fullyCooling = rotator
+      .getStatus()
+      .accounts.find((candidate) => candidate.email === account.config.email);
+    assert.equal(fullyCooling?.status, "cooldown", "all known pools cooling is a global account cooldown");
+  });
+
+  it("preserves persisted Antigravity pool deadlines beyond 30 minutes", async () => {
+    const now = Date.now();
+    const claudeDeadline = now + 4_815_000;
+    const geminiDeadline = now + 3_900_000;
+    const defaultDeadline = now + 4 * 60 * 60 * 1000;
+    const email = "persisted-pools@example.com";
+
+    await setCachedState({
+      modelAccounts: {},
+      accounts: {
+        [email]: {
+          totalRequests: 0,
+          cooldownsByModel: {
+            claude: claudeDeadline,
+            gemini: geminiDeadline,
+            __default__: defaultDeadline,
+          },
+          quotaExhaustedAt: now,
+          disabled: false,
+          flagged: false,
+        },
+      },
+    });
+
+    try {
+      const rotator = new AccountRotator({
+        proxyPort: 51224,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [
+          {
+            email,
+            projectId: "persisted-project",
+            refreshToken: "persisted-refresh",
+          },
+        ],
+      }) as any;
+      rotator.stopQuotaPolling();
+      const restored = rotator.accounts[0] as AccountRuntime;
+
+      assert.equal(restored.cooldownsByModel.claude, claudeDeadline);
+      assert.equal(restored.cooldownsByModel.gemini, geminiDeadline);
+      assert.ok(
+        (restored.cooldownsByModel.__default__ ?? 0) <= Date.now() + 30 * 60 * 1000,
+        "generic stale cooldowns must remain capped",
+      );
+    } finally {
+      await setCachedState({ modelAccounts: {}, accounts: {} });
+    }
   });
 
   it("rotateModel and activateModelAccount do not leak in-flight counters during background polling", async () => {

--- a/test/v2-routing.test.ts
+++ b/test/v2-routing.test.ts
@@ -273,6 +273,64 @@ describe("v2 routing and status", () => {
     }
   });
 
+  it("reconciles an exhausted Google pool cooldown with its latest RAW POLL reset", async () => {
+    const now = Date.now();
+    const claudeResetTime = new Date(now + 51 * 60_000).toISOString();
+    const geminiResetTime = new Date(now + 4 * 60 * 60_000).toISOString();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      assert.match(String(input), /fetchAvailableModels/);
+      return new Response(
+        JSON.stringify({
+          models: {
+            "claude-opus-4-6-thinking": {
+              quotaInfo: { remainingFraction: 0, resetTime: claudeResetTime },
+            },
+            "gemini-3.1-pro": {
+              quotaInfo: { remainingFraction: 0.93, resetTime: geminiResetTime },
+            },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const rotator = new AccountRotator({
+      ...makeConfig(),
+      accounts: [makeConfig().accounts[0]],
+    }) as any;
+    rotator.stopQuotaPolling();
+    const account = rotator.accounts[0];
+    account.accessToken = "test-access-token";
+    account.tokenExpires = now + 60_000;
+    account.cooldownsByModel = { claude: now + 80 * 60_000 };
+
+    let saves = 0;
+    let drains = 0;
+    rotator.scheduleStateSave = () => saves++;
+    rotator.requestWaiterDrain = () => drains++;
+
+    try {
+      await rotator.pollAccountQuota(account);
+
+      assert.equal(
+        account.cooldownsByModel.claude,
+        new Date(claudeResetTime).getTime(),
+      );
+      assert.equal(account.cooldownsByModel.gemini, undefined);
+      assert.equal(account.cooldownsByModel.__default__, undefined);
+      assert.equal(rotator.isRoutableForModel(account, "gemini", Date.now()), true);
+      assert.equal(saves, 1);
+      assert.equal(drains, 1);
+
+      await rotator.pollAccountQuota(account);
+      assert.equal(saves, 1, "an unchanged reset must not schedule another save");
+      assert.equal(drains, 1, "an unchanged reset must not drain waiters again");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("shares one auto-warmup cycle across overlapping quota polls", async () => {
     const originalFetch = globalThis.fetch;
     const requestedModels: string[] = [];

--- a/test/v2-routing.test.ts
+++ b/test/v2-routing.test.ts
@@ -86,7 +86,7 @@ describe("v2 routing and status", () => {
     assert.equal(best?.config.email, "b@example.com");
   });
 
-  it("kickstarts Gemini 3.6 through the shared Gemini 3 upstream model", async () => {
+  it("kickstarts the Gemini pool through the shared Gemini 3 upstream model", async () => {
     const originalFetch = globalThis.fetch;
     let requestBody: { model?: string } | undefined;
     globalThis.fetch = (async (_input, init) => {
@@ -100,9 +100,10 @@ describe("v2 routing and status", () => {
       rotator.accounts[0].accessToken = "test-access-token";
       rotator.accounts[0].tokenExpires = Date.now() + 60_000;
 
+      // The canonical quota pool key for Gemini is "gemini" (from QUOTA_MODEL_KEYS)
       const result = await rotator.kickstartTimerForAccount(
         "a@example.com",
-        "gemini-3.6-flash",
+        "gemini",
       );
       assert.equal(result.ok, true);
       assert.equal(result.upstreamModel, "gemini-3-flash");

--- a/test/v2-routing.test.ts
+++ b/test/v2-routing.test.ts
@@ -1,24 +1,31 @@
-import { describe, it, before, afterEach } from "node:test";
+import { describe, it, before, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Config } from "../src/types.js";
 
-// Keep direct execution of this file from persisting its fixture accounts in
-// the operator's real config directory. `npm test` already sets this env var,
-// but `node --test test/v2-routing.test.ts` does not.
-if (!process.env.TUXEVIL_ROTATOR_DIR) {
-  process.env.TUXEVIL_ROTATOR_DIR = mkdtempSync(
-    join(tmpdir(), "tuxevil-v2-routing-"),
-  );
-}
+const savedEnv = {
+  TUXEVIL_ROTATOR_DIR: process.env.TUXEVIL_ROTATOR_DIR,
+  PI_ROTATOR_DIR: process.env.PI_ROTATOR_DIR,
+  DATABASE_URL: process.env.DATABASE_URL,
+  TUXEVIL_ROTATOR_DATABASE_URL: process.env.TUXEVIL_ROTATOR_DATABASE_URL,
+  PI_ROTATOR_DATABASE_URL: process.env.PI_ROTATOR_DATABASE_URL,
+};
+const testDir = mkdtempSync(join(tmpdir(), "tuxevil-v2-routing-"));
+process.env.TUXEVIL_ROTATOR_DIR = testDir;
+process.env.PI_ROTATOR_DIR = testDir;
+delete process.env.DATABASE_URL;
+delete process.env.TUXEVIL_ROTATOR_DATABASE_URL;
+delete process.env.PI_ROTATOR_DATABASE_URL;
 
 // These modules resolve their config paths during import, so load them only
 // after the isolated test directory has been selected above.
 const { AccountRotator } = await import("../src/rotator.js");
-const { initDb } = await import("../src/db-store.js");
+const { initDb, closeDb } = await import("../src/db-store.js");
 const { setPersistedAdminToken } = await import("../src/admin-auth.js");
+const { getProviderAdapter } = await import("../src/providers/registry.js");
+const { providerAdapterForModel } = await import("../src/proxy.js");
 
 function makeConfig(): Config {
   return {
@@ -52,6 +59,15 @@ function makeConfig(): Config {
 describe("v2 routing and status", () => {
   before(async () => {
     await initDb();
+  });
+
+  after(async () => {
+    await closeDb();
+    rmSync(testDir, { recursive: true, force: true });
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   });
 
   afterEach(() => {
@@ -89,9 +105,16 @@ describe("v2 routing and status", () => {
   it("kickstarts Gemini 3.6 through the shared Gemini 3 upstream model", async () => {
     const originalFetch = globalThis.fetch;
     let requestBody: { model?: string } | undefined;
-    globalThis.fetch = (async (_input, init) => {
-      requestBody = JSON.parse(String(init?.body)) as { model?: string };
-      return new Response("", { status: 200 });
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (url.includes("streamGenerateContent")) {
+        requestBody = JSON.parse(String(init?.body)) as { model?: string };
+        return new Response("", { status: 200 });
+      }
+      if (url.includes("fetchAvailableModels")) {
+        return new Response(JSON.stringify({ models: {} }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch in direct kickstart test: ${url}`);
     }) as typeof fetch;
 
     try {
@@ -107,6 +130,536 @@ describe("v2 routing and status", () => {
       assert.equal(result.ok, true);
       assert.equal(result.upstreamModel, "gemini-3-flash");
       assert.equal(requestBody?.model, "gemini-3-flash");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("kickstarts family pool keys (gemini, claude) and kickstartAllFreshTimers", async () => {
+    const originalFetch = globalThis.fetch;
+    const requestedModels: string[] = [];
+    let quotaPolls = 0;
+    const mockQuotaResponse = {
+      models: {
+        "gemini-3.5-flash": { quotaInfo: { remainingFraction: 1.0, resetTime: null } },
+        "claude-opus-4-6-thinking": { quotaInfo: { remainingFraction: 1.0, resetTime: null } },
+      },
+    };
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (url.includes("streamGenerateContent")) {
+        const body = JSON.parse(String(init?.body)) as { model?: string };
+        if (body.model) requestedModels.push(body.model);
+        return new Response("", { status: 200 });
+      }
+      if (url.includes("fetchAvailableModels")) {
+        quotaPolls++;
+        return new Response(JSON.stringify(mockQuotaResponse), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch in kickstart test: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const rotator = new AccountRotator(makeConfig()) as any;
+      rotator.stopQuotaPolling();
+      rotator.accounts[0].accessToken = "test-access-token";
+      rotator.accounts[0].tokenExpires = Date.now() + 60_000;
+      rotator.accounts[0].quota = [
+        {
+          modelKey: "gemini",
+          displayName: "Gemini",
+          providerId: "google-antigravity",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+        {
+          modelKey: "claude",
+          displayName: "Claude",
+          providerId: "google-antigravity",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+      ];
+
+      const resGemini = await rotator.kickstartTimerForAccount("a@example.com", "gemini");
+      assert.equal(resGemini.ok, true);
+      assert.equal(resGemini.upstreamModel, "gemini-3-flash");
+      assert.equal(quotaPolls, 1, "a direct kickstart must refresh quota immediately");
+
+      quotaPolls = 0;
+      const resClaude = await rotator.kickstartTimerForAccount("a@example.com", "claude");
+      assert.equal(resClaude.ok, true);
+      assert.equal(resClaude.upstreamModel, "gpt-oss-120b-medium");
+      assert.equal(quotaPolls, 1, "a direct kickstart must refresh quota immediately");
+
+      requestedModels.length = 0;
+      quotaPolls = 0;
+      const allRes = await rotator.kickstartAllFreshTimers("a@example.com");
+      assert.equal(allRes.ok, true);
+      assert.equal(allRes.results.length, 2);
+      assert.deepEqual(
+        allRes.results.map((r: any) => r.upstreamModel).sort(),
+        ["gemini-3-flash", "gpt-oss-120b-medium"].sort(),
+      );
+      assert.deepEqual(requestedModels.sort(), ["gemini-3-flash", "gpt-oss-120b-medium"].sort());
+      assert.equal(quotaPolls, 1, "bulk kickstart must perform one account repoll");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("serializes quota polls per account and publishes the trailing snapshot", async () => {
+    const rotator = new AccountRotator(makeConfig()) as any;
+    rotator.stopQuotaPolling();
+    const account = rotator.accounts[0];
+    account.accessToken = "test-access-token";
+    account.tokenExpires = Date.now() + 60_000;
+
+    const adapter = getProviderAdapter("google-antigravity") as any;
+    const originalFetchQuota = adapter.fetchQuota;
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let announceFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      announceFirst = resolve;
+    });
+
+    adapter.fetchQuota = async (target: any) => {
+      calls++;
+      const call = calls;
+      active++;
+      maxActive = Math.max(maxActive, active);
+      try {
+        if (call === 1) {
+          announceFirst();
+          await firstGate;
+        }
+        target.quota = [
+          {
+            modelKey: "claude",
+            displayName: "Claude",
+            providerId: "google-antigravity",
+            percentRemaining: call === 1 ? 10 : 90,
+            resetTime: null,
+            timerType: "fresh",
+          },
+        ];
+      } finally {
+        active--;
+      }
+    };
+
+    try {
+      const first = rotator.pollAccountQuota(account);
+      await firstStarted;
+      const second = rotator.pollAccountQuota(account);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      releaseFirst();
+      await Promise.all([first, second]);
+
+      assert.equal(calls, 2, "one overlapping request must schedule one trailing repoll");
+      assert.equal(maxActive, 1, "quota fetches for one account must never overlap");
+      assert.equal(account.quota[0]?.percentRemaining, 90, "the trailing snapshot must win");
+    } finally {
+      adapter.fetchQuota = originalFetchQuota;
+      releaseFirst();
+    }
+  });
+
+  it("shares one auto-warmup cycle across overlapping quota polls", async () => {
+    const originalFetch = globalThis.fetch;
+    const requestedModels: string[] = [];
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (!url.includes("streamGenerateContent")) {
+        throw new Error(`Unexpected fetch in overlapping warmup test: ${url}`);
+      }
+      const body = JSON.parse(String(init?.body)) as { model?: string };
+      if (body.model) requestedModels.push(body.model);
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+
+    const rotator = new AccountRotator({
+      ...makeConfig(),
+      accounts: [makeConfig().accounts[0]],
+    }) as any;
+    rotator.stopQuotaPolling();
+    const account = rotator.accounts[0];
+    account.accessToken = "test-access-token";
+    account.tokenExpires = Date.now() + 60_000;
+    account.allowFreshWindowStartsOverride = true;
+    account.quota = [
+      {
+        modelKey: "gemini",
+        displayName: "Gemini",
+        providerId: "google-antigravity",
+        percentRemaining: 100,
+        resetTime: null,
+        timerType: "fresh",
+      },
+      {
+        modelKey: "claude",
+        displayName: "Claude",
+        providerId: "google-antigravity",
+        percentRemaining: 100,
+        resetTime: null,
+        timerType: "fresh",
+      },
+    ];
+    rotator.autoWarmupEnabled = true;
+
+    let pollCalls = 0;
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let announceFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      announceFirst = resolve;
+    });
+    rotator.pollAccountQuota = async () => {
+      pollCalls++;
+      if (pollCalls === 1) {
+        announceFirst();
+        await firstGate;
+      }
+      return true;
+    };
+
+    try {
+      const first = rotator.pollAllQuotas();
+      await firstStarted;
+      const second = rotator.pollAllQuotas();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      releaseFirst();
+      await Promise.all([first, second]);
+
+      assert.deepEqual(
+        requestedModels.sort(),
+        ["gemini-3-flash", "gpt-oss-120b-medium"].sort(),
+        "each upstream should be warmed exactly once",
+      );
+      assert.equal(pollCalls, 2, "one initial poll plus one post-warmup repoll");
+    } finally {
+      globalThis.fetch = originalFetch;
+      releaseFirst();
+    }
+  });
+
+  it("kickstarts gpt-oss:20b through Ollama on a Google plus Ollama account", async () => {
+    const config = makeConfig();
+    config.accounts = [
+      {
+        email: "dual-gpt-oss@example.com",
+        credentials: [
+          { provider: "google-antigravity", refreshToken: "g", projectId: "pg" },
+          { provider: "ollama", apiKey: "o" },
+        ],
+      },
+    ];
+    const rotator = new AccountRotator(config) as any;
+    rotator.stopQuotaPolling();
+    const account = rotator.accounts[0];
+    account.accessToken = "google-access-token";
+    account.tokenExpires = Date.now() + 60_000;
+    account.quota = [
+      {
+        modelKey: "session",
+        displayName: "Ollama Session",
+        providerId: "ollama",
+        percentRemaining: 100,
+        resetTime: null,
+        timerType: "fresh",
+      },
+    ];
+
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{
+      url: string;
+      authorization: string | null;
+      body: { model?: string };
+    }> = [];
+    globalThis.fetch = (async (input, init) => {
+      calls.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: JSON.parse(String(init?.body)) as { model?: string },
+      });
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const recordedPools: string[] = [];
+    rotator.recordRequest = (_target: unknown, model: string) => {
+      recordedPools.push(model);
+      return false;
+    };
+    let quotaPolls = 0;
+    rotator.pollAccountQuota = async () => {
+      quotaPolls++;
+      return true;
+    };
+
+    try {
+      const result = await rotator.kickstartTimerForAccount(
+        "dual-gpt-oss@example.com",
+        "gpt-oss:20b",
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(result.upstreamModel, "gpt-oss:20b");
+      assert.equal(calls.length, 1, "the kickstart must make no Google request");
+      assert.match(calls[0].url, /\/api\/chat$/);
+      assert.equal(calls[0].authorization, "Bearer o");
+      assert.equal(calls[0].body.model, "gpt-oss:20b");
+      assert.deepEqual(recordedPools, ["session"]);
+      assert.equal(quotaPolls, 1, "a direct kickstart must refresh quota immediately");
+      assert.equal(providerAdapterForModel(account, "gpt-oss:20b", rotator).id, "ollama");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("uses the Antigravity reset duration for a kickstart 429 on one pool", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            status: "RESOURCE_EXHAUSTED",
+            message: "quota exceeded. Resets in 1h20m14s",
+          },
+        }),
+        { status: 429, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    try {
+      const rotator = new AccountRotator({
+        ...makeConfig(),
+        accounts: [makeConfig().accounts[0]],
+      }) as any;
+      rotator.stopQuotaPolling();
+      const account = rotator.accounts[0];
+      account.accessToken = "test-access-token";
+      account.tokenExpires = Date.now() + 60_000;
+      account.quota = [
+        {
+          modelKey: "claude",
+          displayName: "Claude",
+          providerId: "google-antigravity",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+        {
+          modelKey: "gemini",
+          displayName: "Gemini",
+          providerId: "google-antigravity",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+      ];
+
+      const before = Date.now();
+      const result = await rotator.kickstartTimerForAccount(
+        "a@example.com",
+        "claude",
+        false,
+      );
+      const after = Date.now();
+
+      assert.equal(result.status, 429);
+      assert.ok(account.cooldownsByModel.claude >= before + 4_815_000);
+      assert.ok(account.cooldownsByModel.claude <= after + 4_815_000);
+      assert.equal(account.cooldownsByModel.gemini, undefined);
+      assert.equal(account.cooldownsByModel.__default__, undefined);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls back to 30 minutes for a kickstart RESOURCE_EXHAUSTED without a duration", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: { status: "RESOURCE_EXHAUSTED", message: "quota exceeded" },
+        }),
+        { status: 429, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    try {
+      const rotator = new AccountRotator({
+        ...makeConfig(),
+        accounts: [makeConfig().accounts[0]],
+      }) as any;
+      rotator.stopQuotaPolling();
+      const account = rotator.accounts[0];
+      account.accessToken = "test-access-token";
+      account.tokenExpires = Date.now() + 60_000;
+      account.quota = [
+        {
+          modelKey: "gemini",
+          displayName: "Gemini",
+          providerId: "google-antigravity",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+      ];
+
+      const before = Date.now();
+      const result = await rotator.kickstartTimerForAccount(
+        "a@example.com",
+        "gemini",
+        false,
+      );
+      const after = Date.now();
+
+      assert.equal(result.status, 429);
+      assert.ok(account.cooldownsByModel.gemini >= before + 1_800_000);
+      assert.ok(account.cooldownsByModel.gemini <= after + 1_800_000);
+      assert.equal(account.cooldownsByModel.__default__, undefined);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("caps a generic kickstart 429 retry-after at 30 minutes", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: { status: "RATE_LIMITED", message: "rate limit exceeded" },
+        }),
+        {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "7200",
+          },
+        },
+      )) as typeof fetch;
+
+    try {
+      const rotator = new AccountRotator({
+        ...makeConfig(),
+        accounts: [makeConfig().accounts[0]],
+      }) as any;
+      rotator.stopQuotaPolling();
+      const account = rotator.accounts[0];
+      account.accessToken = "test-access-token";
+      account.tokenExpires = Date.now() + 60_000;
+      account.quota = [
+        {
+          modelKey: "gemini",
+          displayName: "Gemini",
+          providerId: "google-antigravity",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+      ];
+
+      let recordedCooldownMs: number | undefined;
+      rotator.recordProvider429 = (
+        _target: unknown,
+        model: string,
+        cooldownMs: number,
+      ) => {
+        assert.equal(model, "gemini");
+        recordedCooldownMs = cooldownMs;
+      };
+
+      const result = await rotator.kickstartTimerForAccount(
+        "a@example.com",
+        "gemini",
+        false,
+      );
+
+      assert.equal(result.status, 429);
+      assert.equal(recordedCooldownMs, 1_800_000);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps an Ollama kickstart 429 on the session pool", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ error: { message: "too many requests" } }),
+        { status: 429, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    try {
+      const config = makeConfig();
+      config.accounts = [
+        {
+          email: "ollama-429@example.com",
+          credentials: [{ provider: "ollama", apiKey: "ollama-secret" }],
+        },
+      ];
+      const rotator = new AccountRotator(config) as any;
+      rotator.stopQuotaPolling();
+      const account = rotator.accounts[0];
+      account.quota = [
+        {
+          modelKey: "session",
+          displayName: "Ollama Session",
+          providerId: "ollama",
+          percentRemaining: 100,
+          resetTime: null,
+          timerType: "fresh",
+        },
+      ];
+
+      const result = await rotator.kickstartTimerForAccount(
+        "ollama-429@example.com",
+        "gpt-oss:20b",
+        false,
+      );
+
+      assert.equal(result.status, 429);
+      assert.deepEqual(Object.keys(account.cooldownsByModel), ["session"]);
+      assert.equal(account.cooldownsByModel.__default__, undefined);
+      assert.deepEqual(rotator.provider429Events, []);
+      assert.deepEqual(rotator.modelBreakers, {});
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not kickstart a non-fresh pool whose reset time is unknown", async () => {
+    const rotator = new AccountRotator({
+      ...makeConfig(),
+      accounts: [makeConfig().accounts[0]],
+    }) as any;
+    rotator.stopQuotaPolling();
+    rotator.accounts[0].quota = [
+      {
+        modelKey: "gemini",
+        displayName: "Gemini",
+        providerId: "google-antigravity",
+        percentRemaining: 100,
+        resetTime: null,
+        timerType: "5h",
+      },
+    ];
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      throw new Error(`Unexpected fetch for non-fresh timer: ${String(input)}`);
+    }) as typeof fetch;
+    try {
+      const result = await rotator.kickstartAllFreshTimers("a@example.com");
+      assert.deepEqual(result.results, []);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Description

This pull request consolidates the verified quota, cooldown, routing, polling, and dashboard fixes required for reliable multi-account Google Antigravity rotation.

No existing upstream issue covers this regression; the repository contribution guide allows direct pull requests from forks.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Summary

- Make Antigravity cooldowns model-scoped and honor the provider's dynamic reset duration.
- Reconcile fresh RAW POLL reset deadlines without blocking healthy sibling pools.
- Represent untouched 100% Claude/Gemini pools as idle instead of showing a nominal five-hour countdown.
- Harden quota polling, kickstart routing, dashboard state, and regression coverage.

## Changes

| Area | Improvements |
|------|--------------|
| Antigravity 429 handling | Parse explicit `RESOURCE_EXHAUSTED` durations such as `Resets in 1h20m14s`; fall back to 30 minutes when absent. Generic kickstart 429 responses keep the 30-minute cap. |
| Model-scoped cooldowns | Apply cooldowns only to the exhausted Claude or Gemini pool, preserve long deadlines across restarts, and avoid account-wide or sibling-provider blocking. |
| RAW POLL reconciliation | When a successful Google poll reports a pool at 0% with a valid future reset, replace the stale model deadline with that authoritative reset. Invalid, missing, or past resets preserve the existing fallback. |
| Untouched pools | Normalize raw `remainingFraction >= 1` to `fresh` with no reset timestamp, so the dashboard renders `idle` and does not show a fake countdown. A partially used value such as `0.999` remains a real timed window even if it rounds to 100%. |
| Polling concurrency | Serialize per-account quota polls with a trailing repoll, single-flight the full poll cycle, and avoid redundant bulk/auto-warmup refreshes. |
| Kickstart routing | Route `gpt-oss:20b` kickstarts through the Ollama session pool and preserve provider ownership for multi-provider accounts. |
| Dashboard and routing | Keep eligibility, reset labels, account status, and per-model diagnostics aligned with the effective provider/pool state. |
| Tests and maintainability | Add regression coverage for 429 durations, model isolation, dynamic reset reconciliation, idle full quotas, polling single-flight behavior, and routing edge cases. |

## Quality checks

- [x] `npm run check` — 665/665 tests passed across 107 suites; typecheck and lint passed with 0 errors.
- [x] Focused quota, routing, dashboard, and concurrency regressions passed.
- [x] `git diff --check` passed.
- [ ] `npm run coverage` — local Node v26.7.0 is incompatible with the repository's c8/yargs CommonJS loading; it fails before tests run. CI uses Node 22.
- [ ] Shellcheck — not applicable; no shell scripts were changed.
- [ ] Documentation update — behavior is documented in source comments and the PR description; no standalone user guide required.

## Additional context

The RAW POLL evidence showed untouched pools repeatedly reporting a moving reset exactly 300 minutes ahead, while used pools reported decreasing timers. The implementation now treats only the latter as active quota windows.