### PR TITLE
fix(google-antigravity): harden dynamic catalog regressions

### DIFF
--- a/src/account-identity.ts
+++ b/src/account-identity.ts
@@ -84,3 +84,13 @@ export function getCredentialGeneration(
   if (!cred && !details.secret) return "none";
   return `${providerId}:${details.projectId}:${details.providerAccountId}:${details.secret}`;
 }
+
+/** Persist a credential revision without exposing its raw secret. */
+export function getCredentialGenerationFingerprint(
+  account: AccountRuntime | AccountConfig,
+  providerId: string,
+): string {
+  return createHash("sha256")
+    .update(getCredentialGeneration(account, providerId))
+    .digest("hex");
+}

--- a/src/account-identity.ts
+++ b/src/account-identity.ts
@@ -68,3 +68,19 @@ export function getAccountIdentity(
   }
   return `${email}#${creds}`;
 }
+
+/** Identify the exact provider credential revision used by an async operation. */
+export function getCredentialGeneration(
+  account: AccountRuntime | AccountConfig,
+  providerId: string,
+): string {
+  const config = "config" in account ? account.config : account;
+  const norm = normalizeAccountConfig(config);
+  const cred = norm.credentials?.find((candidate) => candidate.provider === providerId);
+  const details = getProviderCredentialDetails(
+    norm,
+    cred ?? { provider: providerId },
+  );
+  if (!cred && !details.secret) return "none";
+  return `${providerId}:${details.projectId}:${details.providerAccountId}:${details.secret}`;
+}

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -2141,12 +2141,25 @@ export interface CompatModelEntry {
   quotaPool: string;
   multimodal: boolean;
   tools: boolean;
+  maxOutputTokens: number;
+  thinkingBudget: number;
+  minThinkingBudget?: number;
+  isThinking: boolean;
 }
 
 export function getEffectiveAntigravityModels(): CompatModelEntry[] {
   const dynamic = dynamicCatalog.getAllModels();
   const seen = new Set(MODEL_CATALOG.map((model) => model.id.toLowerCase()));
-  const result: CompatModelEntry[] = MODEL_CATALOG.map((model) => ({ ...model }));
+  const result: CompatModelEntry[] = MODEL_CATALOG.map((model) => {
+    const spec = getModelSpec(model.id);
+    return {
+      ...model,
+      maxOutputTokens: spec.maxOutputTokens,
+      thinkingBudget: spec.thinkingBudget,
+      minThinkingBudget: spec.minThinkingBudget,
+      isThinking: spec.isThinking,
+    };
+  });
   for (const m of dynamic) {
     if (seen.has(m.id.toLowerCase())) continue;
     seen.add(m.id.toLowerCase());
@@ -2157,6 +2170,10 @@ export function getEffectiveAntigravityModels(): CompatModelEntry[] {
       quotaPool: m.quotaPool,
       multimodal: m.multimodal,
       tools: m.tools,
+      maxOutputTokens: m.maxOutputTokens,
+      thinkingBudget: m.thinkingBudget,
+      minThinkingBudget: m.minThinkingBudget,
+      isThinking: m.isThinking,
     });
   }
   return result;
@@ -2172,7 +2189,18 @@ export function buildOpenAIModelCatalog(
   rotator?: AccountRotator,
 ): OpenAIModelCatalogEntry[] {
   const catalog: OpenAIModelCatalogEntry[] = getEffectiveAntigravityModels().map(
-    ({ id, ctx, family, quotaPool, multimodal, tools }) => ({
+    ({
+      id,
+      ctx,
+      family,
+      quotaPool,
+      multimodal,
+      tools,
+      maxOutputTokens,
+      thinkingBudget,
+      minThinkingBudget,
+      isThinking,
+    }) => ({
       id,
       object: "model",
       created: 0,
@@ -2185,6 +2213,12 @@ export function buildOpenAIModelCatalog(
         quota_pool: quotaPool,
         multimodal,
         tool_calling: tools,
+        max_output_tokens: maxOutputTokens,
+        thinking: isThinking,
+        thinking_budget: thinkingBudget,
+        ...(minThinkingBudget !== undefined
+          ? { min_thinking_budget: minThinkingBudget }
+          : {}),
       },
     }),
   );
@@ -2262,14 +2296,25 @@ export function serveOpenAIModels(
 export function serveGeminiModels(res: ServerResponse): void {
   writeJson(res, 200, {
     models: getEffectiveAntigravityModels().map(
-      ({ id, ctx, family, quotaPool, multimodal, tools }) => ({
+      ({
+        id,
+        ctx,
+        family,
+        quotaPool,
+        multimodal,
+        tools,
+        maxOutputTokens,
+        thinkingBudget,
+        minThinkingBudget,
+        isThinking,
+      }) => ({
         name: `models/${id}`,
         baseModelId: family,
         version: "v2.0",
         displayName: id,
         description: `Tuxevil Rotator Gemini-compatible model entry for ${id}`,
         inputTokenLimit: ctx,
-        outputTokenLimit: ctx,
+        outputTokenLimit: maxOutputTokens,
         supportedGenerationMethods: [
           "generateContent",
           "streamGenerateContent",
@@ -2278,6 +2323,11 @@ export function serveGeminiModels(res: ServerResponse): void {
           tools,
           multimodal,
           quotaPool,
+          thinking: isThinking,
+          thinkingBudget,
+          ...(minThinkingBudget !== undefined
+            ? { minThinkingBudget }
+            : {}),
         },
       }),
     ),

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -35,6 +35,7 @@ import {
   getActiveModelSpecs,
   getModelFamily,
   getModelSpec,
+  getModelSpecOverride,
   isThinkingModel,
 } from "./compat/model-specs.js";
 import type { ModelSpec } from "./compat/model-specs.js";
@@ -2152,8 +2153,11 @@ export function getEffectiveAntigravityModels(): CompatModelEntry[] {
   const seen = new Set(MODEL_CATALOG.map((model) => model.id.toLowerCase()));
   const result: CompatModelEntry[] = MODEL_CATALOG.map((model) => {
     const spec = getModelSpec(model.id);
+    const contextSpec =
+      getModelSpecOverride(model.id) ?? dynamicCatalog.getModelSpec(model.id);
     return {
       ...model,
+      ctx: contextSpec?.contextWindow ?? model.ctx,
       maxOutputTokens: spec.maxOutputTokens,
       thinkingBudget: spec.thinkingBudget,
       minThinkingBudget: spec.minThinkingBudget,
@@ -2163,17 +2167,18 @@ export function getEffectiveAntigravityModels(): CompatModelEntry[] {
   for (const m of dynamic) {
     if (seen.has(m.id.toLowerCase())) continue;
     seen.add(m.id.toLowerCase());
+    const spec = getModelSpec(m.id);
     result.push({
       id: m.id,
       family: m.family,
-      ctx: m.ctx,
+      ctx: spec.contextWindow ?? m.ctx,
       quotaPool: m.quotaPool,
       multimodal: m.multimodal,
       tools: m.tools,
-      maxOutputTokens: m.maxOutputTokens,
-      thinkingBudget: m.thinkingBudget,
-      minThinkingBudget: m.minThinkingBudget,
-      isThinking: m.isThinking,
+      maxOutputTokens: spec.maxOutputTokens,
+      thinkingBudget: spec.thinkingBudget,
+      minThinkingBudget: spec.minThinkingBudget,
+      isThinking: spec.isThinking,
     });
   }
   return result;

--- a/src/compat/model-specs.ts
+++ b/src/compat/model-specs.ts
@@ -3,6 +3,7 @@ import { dynamicCatalog } from "../providers/google-antigravity/dynamic-catalog.
 export interface ModelSpec {
 	maxOutputTokens: number;
 	thinkingBudget: number; // -1 = adaptive (model decides), >=0 = fixed
+	minThinkingBudget?: number;
 	isThinking: boolean;
 	/** Upstream-published context window (input tokens). Optional. */
 	contextWindow?: number;
@@ -32,6 +33,10 @@ export const DEFAULT_MODEL_SPECS: Record<string, ModelSpec> = {
 	"claude-sonnet-4-6-thinking":{ maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 1_000_000 },
 	"claude-opus-4-6-thinking":  { maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 1_000_000 },
 	"claude-opus-4-6":           { maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 1_000_000 },
+	"claude-sonnet-4-5":         { maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 200_000 },
+	"claude-sonnet-4-5-thinking":{ maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 200_000 },
+	"claude-opus-4-5":           { maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 200_000 },
+	"claude-opus-4-5-thinking":  { maxOutputTokens: 64000, thinkingBudget: 32768, isThinking: true, contextWindow: 200_000 },
 	"gpt-oss-120b-medium":       { maxOutputTokens: 32768, thinkingBudget: 8192,  isThinking: true, contextWindow: 131_072 },
 	"gpt-oss-120b":              { maxOutputTokens: 32768, thinkingBudget: 8192,  isThinking: true, contextWindow: 131_072 },
 };
@@ -66,6 +71,19 @@ export function getModelFamily(model: string): "claude" | "gemini" | "unknown" {
 	return "unknown";
 }
 
+/** Resolve bundled static metadata without consulting the dynamic registry. */
+export function getStaticModelSpec(model: string): ModelSpec | undefined {
+	const lower = model.toLowerCase();
+	if (DEFAULT_MODEL_SPECS[lower]) return DEFAULT_MODEL_SPECS[lower];
+	let best: { key: string; spec: ModelSpec } | undefined;
+	for (const [key, spec] of Object.entries(DEFAULT_MODEL_SPECS)) {
+		if (lower.includes(key) && (!best || key.length > best.key.length)) {
+			best = { key, spec };
+		}
+	}
+	return best?.spec;
+}
+
 export function getModelSpec(model: string): ModelSpec {
 	const lower = model.toLowerCase();
 	if (modelSpecsOverride) {
@@ -79,9 +97,8 @@ export function getModelSpec(model: string): ModelSpec {
 	const dynamicSpec = dynamicCatalog.getModelSpec(lower);
 	if (dynamicSpec) return dynamicSpec;
 	if (!modelSpecsOverride) {
-		for (const [key, spec] of Object.entries(DEFAULT_MODEL_SPECS)) {
-			if (lower.includes(key)) return spec;
-		}
+		const staticSpec = getStaticModelSpec(lower);
+		if (staticSpec) return staticSpec;
 	}
 	const family = getModelFamily(model);
 	if (family === "claude") return { maxOutputTokens: CLAUDE_MAX_OUTPUT_TOKENS, thinkingBudget: CLAUDE_DEFAULT_THINKING_BUDGET, isThinking: true, contextWindow: 1_000_000 };
@@ -90,12 +107,5 @@ export function getModelSpec(model: string): ModelSpec {
 }
 
 export function isThinkingModel(model: string): boolean {
-	const spec = getModelSpec(model);
-	if (spec.isThinking) return true;
-	const l = model.toLowerCase();
-	if (l.includes("gemini")) {
-		const m = l.match(/gemini-(\d+)/);
-		if (m && parseInt(m[1], 10) >= 3) return true;
-	}
-	return false;
+	return getModelSpec(model).isThinking;
 }

--- a/src/compat/model-specs.ts
+++ b/src/compat/model-specs.ts
@@ -84,22 +84,24 @@ export function getStaticModelSpec(model: string): ModelSpec | undefined {
 	return best?.spec;
 }
 
+export function getModelSpecOverride(model: string): ModelSpec | undefined {
+	if (!modelSpecsOverride) return undefined;
+	const lower = model.toLowerCase();
+	if (modelSpecsOverride[lower]) return modelSpecsOverride[lower];
+	for (const [key, spec] of Object.entries(modelSpecsOverride)) {
+		if (lower.includes(key)) return spec;
+	}
+	return undefined;
+}
+
 export function getModelSpec(model: string): ModelSpec {
 	const lower = model.toLowerCase();
-	if (modelSpecsOverride) {
-		if (modelSpecsOverride[lower]) return modelSpecsOverride[lower];
-		for (const [key, spec] of Object.entries(modelSpecsOverride)) {
-			if (lower.includes(key)) return spec;
-		}
-	} else if (DEFAULT_MODEL_SPECS[lower]) {
-		return DEFAULT_MODEL_SPECS[lower];
-	}
+	const override = getModelSpecOverride(lower);
+	if (override) return override;
 	const dynamicSpec = dynamicCatalog.getModelSpec(lower);
 	if (dynamicSpec) return dynamicSpec;
-	if (!modelSpecsOverride) {
-		const staticSpec = getStaticModelSpec(lower);
-		if (staticSpec) return staticSpec;
-	}
+	const staticSpec = getStaticModelSpec(lower);
+	if (staticSpec) return staticSpec;
 	const family = getModelFamily(model);
 	if (family === "claude") return { maxOutputTokens: CLAUDE_MAX_OUTPUT_TOKENS, thinkingBudget: CLAUDE_DEFAULT_THINKING_BUDGET, isThinking: true, contextWindow: 1_000_000 };
 	if (family === "gemini") return { maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS, thinkingBudget: FALLBACK_THINKING_BUDGET, isThinking: true, contextWindow: 1_000_000 };

--- a/src/providers/google-antigravity/dynamic-catalog.ts
+++ b/src/providers/google-antigravity/dynamic-catalog.ts
@@ -7,6 +7,7 @@ import {
 import {
   QUOTA_MODEL_KEYS,
   type GoogleQuotaResponse,
+  type PersistedDynamicModelOwnership,
 } from "../../types.js";
 
 export interface DynamicModelEntry {
@@ -31,6 +32,10 @@ const RESERVED_QUOTA_MODEL_IDS = new Set(
 
 type GoogleModelInfo = GoogleQuotaResponse["models"][string];
 type ActiveAccount = string | { id: string; generation: string };
+type PersistedOwnershipAccount = {
+  id: string;
+  credentialGenerationFingerprint: string;
+};
 interface ActiveAccountGeneration {
   credentialGeneration: string | null;
   epoch: number;
@@ -47,6 +52,16 @@ function isSafeModelId(value: string): boolean {
     lower !== "__proto__" &&
     lower !== "prototype" &&
     lower !== "constructor";
+}
+
+function isDiscoverableModelId(value: string): boolean {
+  const id = value.trim();
+  const lower = id.toLowerCase();
+  return isSafeModelId(id) &&
+    !RESERVED_QUOTA_MODEL_IDS.has(lower) &&
+    !lower.startsWith("chat_") &&
+    !lower.startsWith("tab_") &&
+    !lower.startsWith("gemini-3.5-");
 }
 
 /** Validate and sanitize the untrusted runtime catalog response. */
@@ -203,7 +218,8 @@ export class DynamicModelRegistry {
     string,
     Pick<DynamicModelEntry, "id" | "quotaPool">
   >();
-  private liveCatalogHydrated = false;
+  private accountModelOwnership = new Map<string, Set<string>>();
+  private ownershipScopedModels = new Set<string>();
   private activeAccountGenerations: Map<
     string,
     ActiveAccountGeneration
@@ -220,7 +236,8 @@ export class DynamicModelRegistry {
     this.accountModels.clear();
     this.defaultAgentModelIds.clear();
     this.discoveredModels.clear();
-    this.liveCatalogHydrated = false;
+    this.accountModelOwnership.clear();
+    this.ownershipScopedModels.clear();
     this.activeAccountGenerations = null;
     this.nextAccountEpoch = 0;
   }
@@ -260,7 +277,6 @@ export class DynamicModelRegistry {
         accountEpoch,
       )
     ) return 0;
-    this.liveCatalogHydrated = true;
     const previous = this.accountModels.get(key);
     const knownBefore = new Set(this.getAllModels().map((model) => model.id.toLowerCase()));
     const next = new Map<string, DynamicModelEntry>();
@@ -279,13 +295,7 @@ export class DynamicModelRegistry {
     for (const [rawId, info] of Object.entries(data.models)) {
       const normalizedId = rawId.trim();
       const lowerId = normalizedId.toLowerCase();
-      if (
-        !lowerId ||
-        RESERVED_QUOTA_MODEL_IDS.has(lowerId) ||
-        lowerId.startsWith("chat_") ||
-        lowerId.startsWith("tab_") ||
-        lowerId.startsWith("gemini-3.5-")
-      ) continue;
+      if (!isDiscoverableModelId(normalizedId)) continue;
 
       const { family, quotaPool } = DynamicModelRegistry.inferFamilyAndPool(normalizedId);
       const familySpec = familyDefaults(family);
@@ -342,10 +352,12 @@ export class DynamicModelRegistry {
         displayName: info.displayName ?? previous?.get(lowerId)?.displayName ?? normalizedId,
       });
       this.discoveredModels.set(lowerId, { id: normalizedId, quotaPool });
+      this.ownershipScopedModels.add(lowerId);
       if (!knownBefore.has(lowerId)) newModelsCount++;
     }
 
     this.accountModels.set(key, next);
+    this.accountModelOwnership.set(key, new Set(next.keys()));
     return newModelsCount;
   }
 
@@ -374,6 +386,16 @@ export class DynamicModelRegistry {
         (previousGeneration !== undefined && previousGeneration !== nextGeneration)
       ) {
         this.accountModels.delete(key);
+      }
+    }
+    for (const key of this.accountModelOwnership.keys()) {
+      const nextGeneration = active.get(key)?.credentialGeneration;
+      const previousGeneration = previous?.get(key)?.credentialGeneration;
+      if (
+        !active.has(key) ||
+        (previousGeneration !== undefined && previousGeneration !== nextGeneration)
+      ) {
+        this.accountModelOwnership.delete(key);
       }
     }
     for (const key of this.defaultAgentModelIds.keys()) {
@@ -431,13 +453,13 @@ export class DynamicModelRegistry {
   }
 
   hasModelForAccount(accountId: string, id: string): boolean {
-    return this.accountModels
+    return this.accountModelOwnership
       .get(accountKey(accountId))
       ?.has(id.trim().toLowerCase()) ?? false;
   }
 
-  hasLiveCatalogSnapshot(): boolean {
-    return this.liveCatalogHydrated;
+  hasOwnershipForModel(id: string): boolean {
+    return this.ownershipScopedModels.has(id.trim().toLowerCase());
   }
 
   wasDiscovered(id: string): boolean {
@@ -457,6 +479,77 @@ export class DynamicModelRegistry {
     return pools;
   }
 
+  getPersistedModelOwnership(
+    accounts: Iterable<PersistedOwnershipAccount>,
+  ): PersistedDynamicModelOwnership {
+    const persistedAccounts = Object.create(null) as PersistedDynamicModelOwnership["accounts"];
+    for (const account of accounts) {
+      const id = accountKey(account.id);
+      const models = this.accountModelOwnership.get(id);
+      if (!models) continue;
+      persistedAccounts[id] = {
+        credentialGenerationFingerprint:
+          account.credentialGenerationFingerprint,
+        models: Array.from(models).sort(),
+      };
+    }
+    return {
+      scopedModels: Array.from(this.ownershipScopedModels).sort(),
+      accounts: persistedAccounts,
+    };
+  }
+
+  restorePersistedModelOwnership(
+    value: unknown,
+    accounts: Iterable<PersistedOwnershipAccount>,
+  ): void {
+    if (
+      !isRecord(value) ||
+      !Array.isArray(value.scopedModels) ||
+      !isRecord(value.accounts)
+    ) return;
+
+    const expectedGenerations = new Map(
+      Array.from(accounts, (account) => [
+        accountKey(account.id),
+        account.credentialGenerationFingerprint,
+      ]),
+    );
+    const scopedModels = new Set<string>();
+    for (const rawModel of value.scopedModels) {
+      if (typeof rawModel !== "string") continue;
+      const model = rawModel.trim().toLowerCase();
+      if (
+        isDiscoverableModelId(model) &&
+        this.discoveredModels.has(model)
+      ) scopedModels.add(model);
+    }
+
+    const restoredAccounts = new Map<string, Set<string>>();
+    for (const [rawAccountId, rawSnapshot] of Object.entries(value.accounts)) {
+      const accountId = accountKey(rawAccountId);
+      const expectedGeneration = expectedGenerations.get(accountId);
+      if (
+        !expectedGeneration ||
+        !isRecord(rawSnapshot) ||
+        rawSnapshot.credentialGenerationFingerprint !== expectedGeneration ||
+        !Array.isArray(rawSnapshot.models)
+      ) continue;
+      const models = new Set<string>();
+      for (const rawModel of rawSnapshot.models) {
+        if (typeof rawModel !== "string") continue;
+        const model = rawModel.trim().toLowerCase();
+        if (scopedModels.has(model)) models.add(model);
+      }
+      restoredAccounts.set(accountId, models);
+    }
+
+    for (const model of scopedModels) this.ownershipScopedModels.add(model);
+    for (const [accountId, models] of restoredAccounts) {
+      this.accountModelOwnership.set(accountId, models);
+    }
+  }
+
   restoreDiscoveredQuotaPools(value: unknown): void {
     if (!isRecord(value)) return;
     for (const [rawId, rawPool] of Object.entries(value)) {
@@ -465,7 +558,7 @@ export class DynamicModelRegistry {
         ? rawPool.trim().toLowerCase()
         : "";
       if (
-        !isSafeModelId(id) ||
+        !isDiscoverableModelId(id) ||
         (quotaPool !== "gemini" && quotaPool !== "claude")
       ) continue;
       this.discoveredModels.set(id.toLowerCase(), { id, quotaPool });

--- a/src/providers/google-antigravity/dynamic-catalog.ts
+++ b/src/providers/google-antigravity/dynamic-catalog.ts
@@ -40,19 +40,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isSafeModelId(value: string): boolean {
+  const lower = value.toLowerCase();
+  return value.length <= 256 &&
+    /^[a-z0-9][a-z0-9._:/-]*$/i.test(value) &&
+    lower !== "__proto__" &&
+    lower !== "prototype" &&
+    lower !== "constructor";
+}
+
 /** Validate and sanitize the untrusted runtime catalog response. */
 export function parseGoogleQuotaResponse(
   value: unknown,
 ): GoogleQuotaResponse | null {
   if (!isRecord(value) || !isRecord(value.models)) return null;
 
-  const models: GoogleQuotaResponse["models"] = {};
+  const models = Object.create(null) as GoogleQuotaResponse["models"];
   let rawEntryCount = 0;
   let validEntryCount = 0;
   for (const [rawId, rawInfo] of Object.entries(value.models)) {
     rawEntryCount++;
     const id = rawId.trim();
-    if (!id || !isRecord(rawInfo)) continue;
+    if (!isSafeModelId(id) || !isRecord(rawInfo)) continue;
     validEntryCount++;
 
     const info: GoogleModelInfo = {};
@@ -115,18 +124,18 @@ export function parseGoogleQuotaResponse(
   const parsed: GoogleQuotaResponse = { models };
   if (
     typeof value.defaultAgentModelId === "string" &&
-    value.defaultAgentModelId.trim()
+    isSafeModelId(value.defaultAgentModelId.trim())
   ) {
     parsed.defaultAgentModelId = value.defaultAgentModelId.trim();
   }
   if (isRecord(value.tieredModelIds)) {
-    const tieredModelIds: Record<string, string[]> = {};
+    const tieredModelIds = Object.create(null) as Record<string, string[]>;
     for (const [tier, rawIds] of Object.entries(value.tieredModelIds)) {
       if (!Array.isArray(rawIds)) continue;
       const ids = rawIds
         .filter((id): id is string => typeof id === "string")
         .map((id) => id.trim())
-        .filter(Boolean);
+        .filter(isSafeModelId);
       if (ids.length > 0) tieredModelIds[tier] = ids;
     }
     if (Object.keys(tieredModelIds).length > 0) {

--- a/src/providers/google-antigravity/dynamic-catalog.ts
+++ b/src/providers/google-antigravity/dynamic-catalog.ts
@@ -442,6 +442,29 @@ export class DynamicModelRegistry {
       this.discoveredModels.get(id.trim().toLowerCase())?.id;
   }
 
+  getDiscoveredQuotaPools(): Record<string, string> {
+    const pools = Object.create(null) as Record<string, string>;
+    for (const { id, quotaPool } of this.discoveredModels.values()) {
+      pools[id] = quotaPool;
+    }
+    return pools;
+  }
+
+  restoreDiscoveredQuotaPools(value: unknown): void {
+    if (!isRecord(value)) return;
+    for (const [rawId, rawPool] of Object.entries(value)) {
+      const id = rawId.trim();
+      const quotaPool = typeof rawPool === "string"
+        ? rawPool.trim().toLowerCase()
+        : "";
+      if (
+        !isSafeModelId(id) ||
+        (quotaPool !== "gemini" && quotaPool !== "claude")
+      ) continue;
+      this.discoveredModels.set(id.toLowerCase(), { id, quotaPool });
+    }
+  }
+
   getModelSpec(id: string): ModelSpec | undefined {
     const entry = this.getModel(id);
     if (!entry) return undefined;

--- a/src/providers/google-antigravity/dynamic-catalog.ts
+++ b/src/providers/google-antigravity/dynamic-catalog.ts
@@ -1,7 +1,13 @@
 // Dynamic Google Antigravity model availability discovered during quota polling.
 
-import type { ModelSpec } from "../../compat/model-specs.js";
-import type { GoogleQuotaResponse } from "../../types.js";
+import {
+  getStaticModelSpec,
+  type ModelSpec,
+} from "../../compat/model-specs.js";
+import {
+  QUOTA_MODEL_KEYS,
+  type GoogleQuotaResponse,
+} from "../../types.js";
 
 export interface DynamicModelEntry {
   id: string;
@@ -12,12 +18,123 @@ export interface DynamicModelEntry {
   tools: boolean;
   maxOutputTokens: number;
   thinkingBudget: number;
+  minThinkingBudget?: number;
   isThinking: boolean;
   isTiered: boolean;
   displayName?: string;
 }
 
 const DEFAULT_ACCOUNT_KEY = "__default__";
+const RESERVED_QUOTA_MODEL_IDS = new Set(
+  Object.values(QUOTA_MODEL_KEYS).map(({ key }) => key.toLowerCase()),
+);
+
+type GoogleModelInfo = GoogleQuotaResponse["models"][string];
+type ActiveAccount = string | { id: string; generation: string };
+interface ActiveAccountGeneration {
+  credentialGeneration: string | null;
+  epoch: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validate and sanitize the untrusted runtime catalog response. */
+export function parseGoogleQuotaResponse(
+  value: unknown,
+): GoogleQuotaResponse | null {
+  if (!isRecord(value) || !isRecord(value.models)) return null;
+
+  const models: GoogleQuotaResponse["models"] = {};
+  let rawEntryCount = 0;
+  let validEntryCount = 0;
+  for (const [rawId, rawInfo] of Object.entries(value.models)) {
+    rawEntryCount++;
+    const id = rawId.trim();
+    if (!id || !isRecord(rawInfo)) continue;
+    validEntryCount++;
+
+    const info: GoogleModelInfo = {};
+    if (typeof rawInfo.displayName === "string" && rawInfo.displayName.trim()) {
+      info.displayName = rawInfo.displayName.trim();
+    }
+    for (const field of ["maxTokens", "maxOutputTokens"] as const) {
+      const candidate = rawInfo[field];
+      if (typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0) {
+        info[field] = candidate;
+      }
+    }
+    if (
+      typeof rawInfo.thinkingBudget === "number" &&
+      Number.isFinite(rawInfo.thinkingBudget) &&
+      (rawInfo.thinkingBudget === -1 || rawInfo.thinkingBudget >= 0)
+    ) {
+      info.thinkingBudget = rawInfo.thinkingBudget;
+    }
+    if (
+      typeof rawInfo.minThinkingBudget === "number" &&
+      Number.isFinite(rawInfo.minThinkingBudget) &&
+      rawInfo.minThinkingBudget >= 0
+    ) {
+      info.minThinkingBudget = rawInfo.minThinkingBudget;
+    }
+    for (
+      const field of [
+        "supportsThinking",
+        "supportsImages",
+        "supportsVideo",
+      ] as const
+    ) {
+      if (typeof rawInfo[field] === "boolean") info[field] = rawInfo[field];
+    }
+    if (isRecord(rawInfo.quotaInfo)) {
+      const quotaInfo: NonNullable<GoogleModelInfo["quotaInfo"]> = {};
+      const remaining = rawInfo.quotaInfo.remainingFraction;
+      if (
+        typeof remaining === "number" &&
+        Number.isFinite(remaining) &&
+        remaining >= 0 &&
+        remaining <= 1
+      ) {
+        quotaInfo.remainingFraction = remaining;
+      }
+      const resetTime = rawInfo.quotaInfo.resetTime;
+      if (typeof resetTime === "string" && resetTime.trim()) {
+        quotaInfo.resetTime = resetTime;
+      }
+      if (Object.keys(quotaInfo).length > 0) info.quotaInfo = quotaInfo;
+    }
+    models[id] = info;
+  }
+
+  // An explicitly empty catalog is a valid snapshot. A non-empty catalog
+  // containing no usable entries is ambiguous, so retain the last good one.
+  if (rawEntryCount > 0 && validEntryCount === 0) return null;
+
+  const parsed: GoogleQuotaResponse = { models };
+  if (
+    typeof value.defaultAgentModelId === "string" &&
+    value.defaultAgentModelId.trim()
+  ) {
+    parsed.defaultAgentModelId = value.defaultAgentModelId.trim();
+  }
+  if (isRecord(value.tieredModelIds)) {
+    const tieredModelIds: Record<string, string[]> = {};
+    for (const [tier, rawIds] of Object.entries(value.tieredModelIds)) {
+      if (!Array.isArray(rawIds)) continue;
+      const ids = rawIds
+        .filter((id): id is string => typeof id === "string")
+        .map((id) => id.trim())
+        .filter(Boolean);
+      if (ids.length > 0) tieredModelIds[tier] = ids;
+    }
+    if (Object.keys(tieredModelIds).length > 0) {
+      parsed.tieredModelIds = tieredModelIds;
+    }
+  }
+  return parsed;
+}
 
 function accountKey(value: string): string {
   return value.trim();
@@ -73,7 +190,15 @@ export class DynamicModelRegistry {
   private static instance: DynamicModelRegistry | null = null;
   private accountModels = new Map<string, Map<string, DynamicModelEntry>>();
   private defaultAgentModelIds = new Map<string, string>();
-  private discoveredModelIds = new Set<string>();
+  private discoveredModels = new Map<
+    string,
+    Pick<DynamicModelEntry, "id" | "quotaPool">
+  >();
+  private activeAccountGenerations: Map<
+    string,
+    ActiveAccountGeneration
+  > | null = null;
+  private nextAccountEpoch = 0;
 
   static getInstance(): DynamicModelRegistry {
     DynamicModelRegistry.instance ??= new DynamicModelRegistry();
@@ -84,7 +209,9 @@ export class DynamicModelRegistry {
   reset(): void {
     this.accountModels.clear();
     this.defaultAgentModelIds.clear();
-    this.discoveredModelIds.clear();
+    this.discoveredModels.clear();
+    this.activeAccountGenerations = null;
+    this.nextAccountEpoch = 0;
   }
 
   /** Derive the model family and quota pool from a model ID string. */
@@ -106,12 +233,22 @@ export class DynamicModelRegistry {
 
   /** Replace one account's advertised models with its latest successful response. */
   updateFromEndpointResponse(
-    data: GoogleQuotaResponse,
+    value: unknown,
     accountId = DEFAULT_ACCOUNT_KEY,
+    credentialGeneration?: string,
+    accountEpoch?: number,
   ): number {
-    if (!data || typeof data !== "object" || !data.models) return 0;
+    const data = parseGoogleQuotaResponse(value);
+    if (!data) return 0;
 
     const key = accountKey(accountId);
+    if (
+      !this.isAccountGenerationActive(
+        key,
+        credentialGeneration,
+        accountEpoch,
+      )
+    ) return 0;
     const previous = this.accountModels.get(key);
     const knownBefore = new Set(this.getAllModels().map((model) => model.id.toLowerCase()));
     const next = new Map<string, DynamicModelEntry>();
@@ -132,14 +269,27 @@ export class DynamicModelRegistry {
       const lowerId = normalizedId.toLowerCase();
       if (
         !lowerId ||
+        RESERVED_QUOTA_MODEL_IDS.has(lowerId) ||
         lowerId.startsWith("chat_") ||
         lowerId.startsWith("tab_") ||
         lowerId.startsWith("gemini-3.5-")
       ) continue;
 
-      this.discoveredModelIds.add(lowerId);
       const { family, quotaPool } = DynamicModelRegistry.inferFamilyAndPool(normalizedId);
-      const defaults = previous?.get(lowerId) ?? familyDefaults(family);
+      const familySpec = familyDefaults(family);
+      const staticSpec = getStaticModelSpec(normalizedId);
+      const defaults = previous?.get(lowerId) ?? {
+        ...familySpec,
+        ...(staticSpec
+          ? {
+              ctx: staticSpec.contextWindow ?? familySpec.ctx,
+              maxOutputTokens: staticSpec.maxOutputTokens,
+              thinkingBudget: staticSpec.thinkingBudget,
+              minThinkingBudget: staticSpec.minThinkingBudget,
+              isThinking: staticSpec.isThinking,
+            }
+          : {}),
+      };
       const isTiered = lowerId.includes("-tiered") || tieredIds.has(lowerId);
       const hasThinkingBudget = typeof info.thinkingBudget === "number";
       const thinkingBudget = hasThinkingBudget
@@ -171,10 +321,15 @@ export class DynamicModelRegistry {
             ? info.maxOutputTokens
             : defaults.maxOutputTokens,
         thinkingBudget,
+        minThinkingBudget:
+          typeof info.minThinkingBudget === "number"
+            ? info.minThinkingBudget
+            : defaults.minThinkingBudget,
         isThinking,
         isTiered,
         displayName: info.displayName ?? previous?.get(lowerId)?.displayName ?? normalizedId,
       });
+      this.discoveredModels.set(lowerId, { id: normalizedId, quotaPool });
       if (!knownBefore.has(lowerId)) newModelsCount++;
     }
 
@@ -183,14 +338,67 @@ export class DynamicModelRegistry {
   }
 
   /** Expire catalogs belonging to accounts that are no longer active. */
-  retainAccounts(accountIds: Iterable<string>): void {
-    const active = new Set(Array.from(accountIds, accountKey));
+  retainAccounts(accounts: Iterable<ActiveAccount>): void {
+    const previous = this.activeAccountGenerations;
+    const active = new Map<string, ActiveAccountGeneration>();
+    for (const account of accounts) {
+      const key = accountKey(typeof account === "string" ? account : account.id);
+      const credentialGeneration = typeof account === "string"
+        ? null
+        : account.generation;
+      const prior = previous?.get(key);
+      active.set(
+        key,
+        prior?.credentialGeneration === credentialGeneration
+          ? prior
+          : { credentialGeneration, epoch: ++this.nextAccountEpoch },
+      );
+    }
     for (const key of this.accountModels.keys()) {
-      if (!active.has(key)) this.accountModels.delete(key);
+      const nextGeneration = active.get(key)?.credentialGeneration;
+      const previousGeneration = previous?.get(key)?.credentialGeneration;
+      if (
+        !active.has(key) ||
+        (previousGeneration !== undefined && previousGeneration !== nextGeneration)
+      ) {
+        this.accountModels.delete(key);
+      }
     }
     for (const key of this.defaultAgentModelIds.keys()) {
-      if (!active.has(key)) this.defaultAgentModelIds.delete(key);
+      if (!this.accountModels.has(key)) this.defaultAgentModelIds.delete(key);
     }
+    this.activeAccountGenerations = active;
+  }
+
+  captureAccountEpoch(
+    accountId: string,
+    credentialGeneration: string,
+  ): number | null | undefined {
+    if (!this.activeAccountGenerations) return undefined;
+    const active = this.activeAccountGenerations.get(accountKey(accountId));
+    if (
+      !active ||
+      (active.credentialGeneration !== null &&
+        active.credentialGeneration !== credentialGeneration)
+    ) {
+      return null;
+    }
+    return active.epoch;
+  }
+
+  isAccountGenerationActive(
+    accountId: string,
+    credentialGeneration?: string,
+    accountEpoch?: number,
+  ): boolean {
+    if (!this.activeAccountGenerations) return true;
+    const key = accountKey(accountId);
+    const active = this.activeAccountGenerations.get(key);
+    if (!active) return false;
+    if (accountEpoch !== undefined && active.epoch !== accountEpoch) return false;
+    return credentialGeneration === undefined ||
+      active.credentialGeneration === null ||
+      active.credentialGeneration === credentialGeneration;
   }
 
   getAllModels(): DynamicModelEntry[] {
@@ -217,7 +425,12 @@ export class DynamicModelRegistry {
   }
 
   wasDiscovered(id: string): boolean {
-    return this.discoveredModelIds.has(id.trim().toLowerCase());
+    return this.discoveredModels.has(id.trim().toLowerCase());
+  }
+
+  getObservedModelId(id: string): string | undefined {
+    return this.getModel(id)?.id ??
+      this.discoveredModels.get(id.trim().toLowerCase())?.id;
   }
 
   getModelSpec(id: string): ModelSpec | undefined {
@@ -226,6 +439,9 @@ export class DynamicModelRegistry {
     return {
       maxOutputTokens: entry.maxOutputTokens,
       thinkingBudget: entry.thinkingBudget,
+      ...(entry.minThinkingBudget !== undefined
+        ? { minThinkingBudget: entry.minThinkingBudget }
+        : {}),
       isThinking: entry.isThinking,
       contextWindow: entry.ctx,
     };
@@ -241,7 +457,9 @@ export class DynamicModelRegistry {
   }
 
   resolveQuotaPool(id: string): string | undefined {
-    return this.getModel(id)?.quotaPool;
+    const lowerId = id.trim().toLowerCase();
+    return this.getModel(lowerId)?.quotaPool ??
+      this.discoveredModels.get(lowerId)?.quotaPool;
   }
 
   getDefaultAgentModelId(): string | null {

--- a/src/providers/google-antigravity/dynamic-catalog.ts
+++ b/src/providers/google-antigravity/dynamic-catalog.ts
@@ -203,6 +203,7 @@ export class DynamicModelRegistry {
     string,
     Pick<DynamicModelEntry, "id" | "quotaPool">
   >();
+  private liveDiscoveredModels = new Set<string>();
   private activeAccountGenerations: Map<
     string,
     ActiveAccountGeneration
@@ -219,6 +220,7 @@ export class DynamicModelRegistry {
     this.accountModels.clear();
     this.defaultAgentModelIds.clear();
     this.discoveredModels.clear();
+    this.liveDiscoveredModels.clear();
     this.activeAccountGenerations = null;
     this.nextAccountEpoch = 0;
   }
@@ -339,6 +341,7 @@ export class DynamicModelRegistry {
         displayName: info.displayName ?? previous?.get(lowerId)?.displayName ?? normalizedId,
       });
       this.discoveredModels.set(lowerId, { id: normalizedId, quotaPool });
+      this.liveDiscoveredModels.add(lowerId);
       if (!knownBefore.has(lowerId)) newModelsCount++;
     }
 
@@ -435,6 +438,10 @@ export class DynamicModelRegistry {
 
   wasDiscovered(id: string): boolean {
     return this.discoveredModels.has(id.trim().toLowerCase());
+  }
+
+  wasDiscoveredFromLiveCatalog(id: string): boolean {
+    return this.liveDiscoveredModels.has(id.trim().toLowerCase());
   }
 
   getObservedModelId(id: string): string | undefined {

--- a/src/providers/google-antigravity/dynamic-catalog.ts
+++ b/src/providers/google-antigravity/dynamic-catalog.ts
@@ -203,7 +203,7 @@ export class DynamicModelRegistry {
     string,
     Pick<DynamicModelEntry, "id" | "quotaPool">
   >();
-  private liveDiscoveredModels = new Set<string>();
+  private liveCatalogHydrated = false;
   private activeAccountGenerations: Map<
     string,
     ActiveAccountGeneration
@@ -220,7 +220,7 @@ export class DynamicModelRegistry {
     this.accountModels.clear();
     this.defaultAgentModelIds.clear();
     this.discoveredModels.clear();
-    this.liveDiscoveredModels.clear();
+    this.liveCatalogHydrated = false;
     this.activeAccountGenerations = null;
     this.nextAccountEpoch = 0;
   }
@@ -260,6 +260,7 @@ export class DynamicModelRegistry {
         accountEpoch,
       )
     ) return 0;
+    this.liveCatalogHydrated = true;
     const previous = this.accountModels.get(key);
     const knownBefore = new Set(this.getAllModels().map((model) => model.id.toLowerCase()));
     const next = new Map<string, DynamicModelEntry>();
@@ -341,7 +342,6 @@ export class DynamicModelRegistry {
         displayName: info.displayName ?? previous?.get(lowerId)?.displayName ?? normalizedId,
       });
       this.discoveredModels.set(lowerId, { id: normalizedId, quotaPool });
-      this.liveDiscoveredModels.add(lowerId);
       if (!knownBefore.has(lowerId)) newModelsCount++;
     }
 
@@ -436,12 +436,12 @@ export class DynamicModelRegistry {
       ?.has(id.trim().toLowerCase()) ?? false;
   }
 
-  wasDiscovered(id: string): boolean {
-    return this.discoveredModels.has(id.trim().toLowerCase());
+  hasLiveCatalogSnapshot(): boolean {
+    return this.liveCatalogHydrated;
   }
 
-  wasDiscoveredFromLiveCatalog(id: string): boolean {
-    return this.liveDiscoveredModels.has(id.trim().toLowerCase());
+  wasDiscovered(id: string): boolean {
+    return this.discoveredModels.has(id.trim().toLowerCase());
   }
 
   getObservedModelId(id: string): string | undefined {

--- a/src/providers/google-antigravity/quota.ts
+++ b/src/providers/google-antigravity/quota.ts
@@ -12,13 +12,31 @@ import {
   QUOTA_MODEL_KEYS,
 } from "../../types.js";
 import { fetchWithRetry } from "../../fetch-with-retry.js";
-import { getAccountIdentity } from "../../account-identity.js";
+import {
+  getAccountIdentity,
+  getCredentialGeneration,
+} from "../../account-identity.js";
 import type { QuotaFetchContext } from "../adapter.js";
 import { DEFAULT_PROVIDER, getProviderProjectId } from "../credential-helpers.js";
 import { getAccountProxyDispatcher } from "../proxy-dispatcher.js";
 import { sortQuotaPools } from "../registry.js";
 
-import { dynamicCatalog, DynamicModelRegistry } from "./dynamic-catalog.js";
+import {
+  dynamicCatalog,
+  DynamicModelRegistry,
+  parseGoogleQuotaResponse,
+} from "./dynamic-catalog.js";
+
+type GoogleModelInfo = GoogleQuotaResponse["models"][string];
+
+function hasUsableQuotaInfo(
+  info: GoogleModelInfo | undefined,
+): info is GoogleModelInfo & { quotaInfo: NonNullable<GoogleModelInfo["quotaInfo"]> } {
+  if (!info?.quotaInfo) return false;
+  const remaining = info.quotaInfo.remainingFraction;
+  return remaining === undefined ||
+    (typeof remaining === "number" && Number.isFinite(remaining));
+}
 
 /**
  * Extract per-model quotas from a Google quota response, preserving the
@@ -32,18 +50,21 @@ export function extractQuotas(
   const now = Date.now();
 
   for (const [, config] of Object.entries(QUOTA_MODEL_KEYS)) {
-    let modelInfo = data.models[config.key];
-
-    if (!modelInfo) {
-      for (const altKey of config.altKeys) {
-        modelInfo = data.models[altKey];
-        if (modelInfo) break;
+    let modelInfo: GoogleModelInfo | undefined;
+    for (const candidate of [config.key, ...config.altKeys]) {
+      const info = data.models[candidate];
+      if (hasUsableQuotaInfo(info)) {
+        modelInfo = info;
+        break;
       }
     }
 
     if (!modelInfo) {
       for (const [modelKey, info] of Object.entries(data.models)) {
-        if (DynamicModelRegistry.inferFamilyAndPool(modelKey).quotaPool === config.key) {
+        if (
+          DynamicModelRegistry.inferFamilyAndPool(modelKey).quotaPool === config.key &&
+          hasUsableQuotaInfo(info)
+        ) {
           modelInfo = info;
           break;
         }
@@ -98,6 +119,16 @@ export async function fetchProviderQuota(
   ctx: QuotaFetchContext,
 ): Promise<void> {
   if (!account.accessToken) return;
+  const accountId = getAccountIdentity(account);
+  const credentialGeneration = getCredentialGeneration(
+    account,
+    DEFAULT_PROVIDER,
+  );
+  const accountEpoch = dynamicCatalog.captureAccountEpoch(
+    accountId,
+    credentialGeneration,
+  );
+  if (accountEpoch === null) return;
 
   try {
     const response = await fetchWithRetry(QUOTA_API_URL, {
@@ -130,10 +161,24 @@ export async function fetchProviderQuota(
       return;
     }
 
-    const data = (await response.json()) as GoogleQuotaResponse;
+    const data = parseGoogleQuotaResponse(await response.json());
+    if (!data) return;
+    if (
+      accountId !== getAccountIdentity(account) ||
+      credentialGeneration !== getCredentialGeneration(account, DEFAULT_PROVIDER) ||
+      !dynamicCatalog.isAccountGenerationActive(
+        accountId,
+        credentialGeneration,
+        accountEpoch,
+      )
+    ) {
+      return;
+    }
     const newModels = dynamicCatalog.updateFromEndpointResponse(
       data,
-      getAccountIdentity(account),
+      accountId,
+      credentialGeneration,
+      accountEpoch,
     );
     if (newModels > 0) {
       ctx.log(

--- a/src/providers/google-antigravity/quota.ts
+++ b/src/providers/google-antigravity/quota.ts
@@ -28,14 +28,21 @@ import {
 } from "./dynamic-catalog.js";
 
 type GoogleModelInfo = GoogleQuotaResponse["models"][string];
+type GoogleModelInfoWithQuota = GoogleModelInfo & {
+  quotaInfo: NonNullable<GoogleModelInfo["quotaInfo"]> & {
+    remainingFraction: number;
+  };
+};
 
 function hasUsableQuotaInfo(
   info: GoogleModelInfo | undefined,
-): info is GoogleModelInfo & { quotaInfo: NonNullable<GoogleModelInfo["quotaInfo"]> } {
+): info is GoogleModelInfoWithQuota {
   if (!info?.quotaInfo) return false;
   const remaining = info.quotaInfo.remainingFraction;
-  return remaining === undefined ||
-    (typeof remaining === "number" && Number.isFinite(remaining));
+  return typeof remaining === "number" &&
+    Number.isFinite(remaining) &&
+    remaining >= 0 &&
+    remaining <= 1;
 }
 
 /**
@@ -50,7 +57,7 @@ export function extractQuotas(
   const now = Date.now();
 
   for (const [, config] of Object.entries(QUOTA_MODEL_KEYS)) {
-    let modelInfo: GoogleModelInfo | undefined;
+    let modelInfo: GoogleModelInfoWithQuota | undefined;
     for (const candidate of [config.key, ...config.altKeys]) {
       const info = data.models[candidate];
       if (hasUsableQuotaInfo(info)) {
@@ -72,7 +79,7 @@ export function extractQuotas(
     }
 
     if (modelInfo?.quotaInfo) {
-      const remainingFraction = modelInfo.quotaInfo.remainingFraction ?? 0;
+      const remainingFraction = modelInfo.quotaInfo.remainingFraction;
       // Google can publish a nominal reset for an untouched pool; no usage means
       // there is no active quota window yet.
       const resetTime =
@@ -188,6 +195,7 @@ export async function fetchProviderQuota(
     }
     const oldQuota = account.quota || [];
     const fresh = extractQuotas(data, oldQuota);
+    if (fresh.length === 0) return;
     // Drop the previous Antigravity entries so the new ones fully replace
     // them; keep entries from OTHER providers (Ollama) so multi-provider
     // accounts accumulate quotas across credentials without overwriting

--- a/src/providers/google-antigravity/quota.ts
+++ b/src/providers/google-antigravity/quota.ts
@@ -129,6 +129,14 @@ export async function fetchProviderQuota(
     credentialGeneration,
   );
   if (accountEpoch === null) return;
+  const isCurrentGeneration = (): boolean =>
+    accountId === getAccountIdentity(account) &&
+    credentialGeneration === getCredentialGeneration(account, DEFAULT_PROVIDER) &&
+    dynamicCatalog.isAccountGenerationActive(
+      accountId,
+      credentialGeneration,
+      accountEpoch,
+    );
 
   try {
     const response = await fetchWithRetry(QUOTA_API_URL, {
@@ -144,10 +152,12 @@ export async function fetchProviderQuota(
       timeoutMs: 8000,
       dispatcher: getAccountProxyDispatcher(account, "google-antigravity"),
     });
+    if (!isCurrentGeneration()) return;
 
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
         const errorText = await response.text();
+        if (!isCurrentGeneration()) return;
         ctx.log(
           `${account.config.email}: quota API returned ${response.status}, flagging account`,
         );
@@ -161,19 +171,10 @@ export async function fetchProviderQuota(
       return;
     }
 
-    const data = parseGoogleQuotaResponse(await response.json());
+    const rawData = await response.json();
+    if (!isCurrentGeneration()) return;
+    const data = parseGoogleQuotaResponse(rawData);
     if (!data) return;
-    if (
-      accountId !== getAccountIdentity(account) ||
-      credentialGeneration !== getCredentialGeneration(account, DEFAULT_PROVIDER) ||
-      !dynamicCatalog.isAccountGenerationActive(
-        accountId,
-        credentialGeneration,
-        accountEpoch,
-      )
-    ) {
-      return;
-    }
     const newModels = dynamicCatalog.updateFromEndpointResponse(
       data,
       accountId,

--- a/src/providers/google-antigravity/quota.ts
+++ b/src/providers/google-antigravity/quota.ts
@@ -182,6 +182,9 @@ export async function fetchProviderQuota(
     if (!isCurrentGeneration()) return;
     const data = parseGoogleQuotaResponse(rawData);
     if (!data) return;
+    const oldQuota = account.quota || [];
+    const fresh = extractQuotas(data, oldQuota);
+    if (fresh.length === 0) return;
     const newModels = dynamicCatalog.updateFromEndpointResponse(
       data,
       accountId,
@@ -193,9 +196,6 @@ export async function fetchProviderQuota(
         `${account.config.email}: discovered ${newModels} Antigravity model(s) from quota response`,
       );
     }
-    const oldQuota = account.quota || [];
-    const fresh = extractQuotas(data, oldQuota);
-    if (fresh.length === 0) return;
     // Drop the previous Antigravity entries so the new ones fully replace
     // them; keep entries from OTHER providers (Ollama) so multi-provider
     // accounts accumulate quotas across credentials without overwriting

--- a/src/providers/google-antigravity/translators.ts
+++ b/src/providers/google-antigravity/translators.ts
@@ -11,6 +11,7 @@ import {
   getModelSpec,
   isThinkingModel,
 } from "../../compat/model-specs.js";
+import { dynamicCatalog } from "./dynamic-catalog.js";
 import {
   thoughtSignatureCache,
   getStoredResponse,
@@ -21,6 +22,32 @@ import {
 const compatLogger = logger.child("compat");
 
 const VALIDATION_LOG_MAX_CHARS = 200;
+
+function normalizeFixedThinking(
+  modelSpec: ReturnType<typeof getModelSpec>,
+  requestedMaxOutputTokens: number | undefined,
+): { budget?: number; maxOutputTokens: number | undefined } {
+  const outputLimit = Math.max(1, Math.floor(modelSpec.maxOutputTokens));
+  const minimum = typeof modelSpec.minThinkingBudget === "number" &&
+      Number.isFinite(modelSpec.minThinkingBudget)
+    ? Math.max(0, Math.floor(modelSpec.minThinkingBudget))
+    : 0;
+  let budget = Math.max(
+    minimum,
+    Math.max(0, Math.floor(modelSpec.thinkingBudget)),
+  );
+  budget = Math.min(budget, outputLimit - 1);
+  if (budget < minimum) {
+    return { maxOutputTokens: requestedMaxOutputTokens };
+  }
+
+  let maxOutputTokens = requestedMaxOutputTokens;
+  if (!maxOutputTokens || maxOutputTokens <= budget) {
+    maxOutputTokens = Math.min(budget + 8192, outputLimit);
+    if (maxOutputTokens <= budget) maxOutputTokens = budget + 1;
+  }
+  return { budget, maxOutputTokens };
+}
 
 export function logValidationFailure(scope: string, payload: unknown): void {
   const truncated = redactSensitive(JSON.stringify(payload));
@@ -842,7 +869,6 @@ export function convertResponsesToChatRequest(
  * reasoning_effort. Matched case-insensitively against the exact ID only;
  * virtual siblings (e.g. `gemini-3.7-flash-tiered-high`) are excluded.
  */
-import { dynamicCatalog } from "./dynamic-catalog.js";
 
 export const TIERED_EFFORT_MODEL_ID = "gemini-3.7-flash-tiered";
 export const TIERED_EFFORT_MODEL_IDS = new Set([
@@ -1193,13 +1219,22 @@ export function openAIToAntigravityBody(
 
   let thinkingConfigObj: Record<string, unknown> | undefined;
   if (modelFamily === "claude" && isThinking && !forcesToolUse(input.tool_choice)) {
-    const tb = modelSpec.thinkingBudget;
-    thinkingConfigObj = { include_thoughts: true, thinking_budget: tb };
-    if (!maxOutputTokens || maxOutputTokens <= tb) {
-      maxOutputTokens = Math.min(tb + 8192, modelSpec.maxOutputTokens);
-      compatLogger.debug(
-        `Adjusted Claude maxOutputTokens → ${maxOutputTokens}`,
-      );
+    if (modelSpec.thinkingBudget === -1) {
+      thinkingConfigObj = { include_thoughts: true };
+    } else {
+      const normalized = normalizeFixedThinking(modelSpec, maxOutputTokens);
+      if (normalized.budget !== undefined) {
+        thinkingConfigObj = {
+          include_thoughts: true,
+          thinking_budget: normalized.budget,
+        };
+      }
+      if (maxOutputTokens !== normalized.maxOutputTokens) {
+        maxOutputTokens = normalized.maxOutputTokens;
+        compatLogger.debug(
+          `Adjusted Claude maxOutputTokens → ${maxOutputTokens}`,
+        );
+      }
     }
   } else if (isThinking && modelFamily !== "claude") {
     const tb = modelSpec.thinkingBudget;
@@ -1222,37 +1257,29 @@ export function openAIToAntigravityBody(
       };
     } else if (tb === -1) {
       thinkingConfigObj = { includeThoughts: true };
-    } else {
-      thinkingConfigObj = { includeThoughts: true, thinkingBudget: tb };
-    }
-    if (tb !== -1 && (!maxOutputTokens || maxOutputTokens <= tb)) {
-      maxOutputTokens = Math.min(tb + 8192, modelSpec.maxOutputTokens);
-      compatLogger.debug(
-        `Adjusted Gemini maxOutputTokens → ${maxOutputTokens}`,
-      );
-    } else if (tb === -1 && maxOutputTokens !== undefined) {
-      // Adaptive thinking models (e.g. gemini-3.8-flash-*, gemini-3.7-flash-tiered)
-      // allocate tokens to thinking first. If a client specifies a small max_tokens
-      // (e.g. 500), thinking tokens consume the entire budget and truncate visible output.
-      // Ensure sufficient headroom above client's requested output tokens.
-      const adaptiveHeadroom = 8192;
-      const minAdaptiveFloor = 8192;
-      const targetTokens = Math.max(maxOutputTokens + adaptiveHeadroom, minAdaptiveFloor);
-      if (maxOutputTokens < targetTokens) {
+      if (maxOutputTokens !== undefined) {
+        // Adaptive models spend from the output budget before emitting visible text.
+        const targetTokens = Math.max(maxOutputTokens + 8192, 8192);
         maxOutputTokens = Math.min(targetTokens, modelSpec.maxOutputTokens);
         compatLogger.debug(
           `Adjusted adaptive Gemini maxOutputTokens → ${maxOutputTokens}`,
         );
       }
+    } else {
+      const normalized = normalizeFixedThinking(modelSpec, maxOutputTokens);
+      if (normalized.budget !== undefined) {
+        thinkingConfigObj = {
+          includeThoughts: true,
+          thinkingBudget: normalized.budget,
+        };
+      }
+      if (maxOutputTokens !== normalized.maxOutputTokens) {
+        maxOutputTokens = normalized.maxOutputTokens;
+        compatLogger.debug(
+          `Adjusted Gemini maxOutputTokens → ${maxOutputTokens}`,
+        );
+      }
     }
-  } else if (input.reasoning_effort) {
-    const budgets: Record<string, number> = {
-      low: Math.round(modelSpec.thinkingBudget / 4),
-      medium: Math.round(modelSpec.thinkingBudget / 2),
-      high: modelSpec.thinkingBudget,
-    };
-    const b = budgets[input.reasoning_effort.toLowerCase()];
-    if (b) thinkingConfigObj = { includeThoughts: true, thinkingBudget: b };
   }
 
   const generationConfig: Record<string, unknown> = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -132,6 +132,13 @@ function routingModelKey(rotator: AccountRotator, model: string): string {
   }).resolveQuotaModelKeyForDisplay;
   return resolver?.call(rotator, model) ?? resolveQuotaModelKey(model) ?? model;
 }
+
+function observedModelKey(rotator: AccountRotator, model: string): string {
+  const resolver = (rotator as unknown as {
+    resolveObservedModelKey?: (value: string) => string;
+  }).resolveObservedModelKey;
+  return resolver?.call(rotator, model) ?? resolveDisplayModelKey(model);
+}
 import { startVersionChecker, performSelfUpdate } from "./version-check.js";
 import { startNotificationPoller } from "./notification-poller.js";
 import {
@@ -1173,7 +1180,7 @@ export async function withRotation<T>(
 
     const label = account.config.label || account.config.email;
     const modelKey = routingModelKey(rotator, model);
-    const displayModelKey = resolveDisplayModelKey(body.displayModel || model);
+    const displayModelKey = observedModelKey(rotator, body.displayModel || model);
     const requestId = `${modelKey}-${Date.now().toString(36)}-${attempt + 1}`;
     const requestStartMs = Date.now();
     let accountReleased = false;
@@ -1609,7 +1616,7 @@ async function handleProxyRequest(
 
     const label = account.config.label || account.config.email;
     const modelKey = rotator.resolveQuotaModelKeyForDisplay(body.model) ?? body.model; // quota routing
-    const displayModelKey = resolveDisplayModelKey(body.model); // metrics/logs
+    const displayModelKey = observedModelKey(rotator, body.model); // metrics/logs
     const requestId = `${modelKey}-${Date.now().toString(36)}-${attempt + 1}`;
     let accountReleased = false;
     const releaseCurrentAccount = (): void => {

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -493,6 +493,7 @@ export class AccountRotator {
     }
 
     try {
+      dynamicCatalog.restoreDiscoveredQuotaPools(state.dynamicModelQuotaPools);
       // Load per-model account assignments
       if (state.modelAccounts) {
         for (const [model, idx] of Object.entries(state.modelAccounts)) {
@@ -667,6 +668,7 @@ export class AccountRotator {
     }
 
     const state: PersistedState = {
+      dynamicModelQuotaPools: dynamicCatalog.getDiscoveredQuotaPools(),
       modelAccounts,
       modelRequestCounts,
       modelStickyAccounts,

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -91,6 +91,7 @@ import {
 import {
   getAccountIdentity,
   getCredentialGeneration,
+  getCredentialGenerationFingerprint,
   getProviderCredentialDetails,
 } from "./account-identity.js";
 
@@ -494,6 +495,16 @@ export class AccountRotator {
 
     try {
       dynamicCatalog.restoreDiscoveredQuotaPools(state.dynamicModelQuotaPools);
+      dynamicCatalog.restorePersistedModelOwnership(
+        state.dynamicModelOwnership,
+        this.accounts
+          .filter((account) => hasCredential(account.config, DEFAULT_PROVIDER))
+          .map((account) => ({
+            id: getAccountIdentity(account),
+            credentialGenerationFingerprint:
+              getCredentialGenerationFingerprint(account, DEFAULT_PROVIDER),
+          })),
+      );
       // Load per-model account assignments
       if (state.modelAccounts) {
         for (const [model, idx] of Object.entries(state.modelAccounts)) {
@@ -669,6 +680,21 @@ export class AccountRotator {
 
     const state: PersistedState = {
       dynamicModelQuotaPools: dynamicCatalog.getDiscoveredQuotaPools(),
+      dynamicModelOwnership: dynamicCatalog.getPersistedModelOwnership(
+        this.accounts
+          .filter(
+            (account) =>
+              !account.disabled &&
+              !account.flagged &&
+              !account.invalidProviders?.[DEFAULT_PROVIDER] &&
+              hasCredential(account.config, DEFAULT_PROVIDER),
+          )
+          .map((account) => ({
+            id: getAccountIdentity(account),
+            credentialGenerationFingerprint:
+              getCredentialGenerationFingerprint(account, DEFAULT_PROVIDER),
+          })),
+      ),
       modelAccounts,
       modelRequestCounts,
       modelStickyAccounts,
@@ -3556,8 +3582,7 @@ export class AccountRotator {
     const accountId = getAccountIdentity(account);
     if (
       !isStaticAntigravityModel(modelKey) &&
-      dynamicCatalog.wasDiscovered(modelKey) &&
-      dynamicCatalog.hasLiveCatalogSnapshot() &&
+      dynamicCatalog.hasOwnershipForModel(modelKey) &&
       !dynamicCatalog.hasModelForAccount(accountId, modelKey)
     ) {
       return false;

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -549,6 +549,7 @@ export class AccountRotator {
             saved.allowFreshWindowStartsOverride ?? false;
         }
       }
+      this.migratePersistedQuotaStateKeys();
       // Cap generic stale cooldowns to 30 min max from now. Antigravity's
       // explicit Claude/Gemini reset deadlines must survive restarts intact.
       const maxCooldown = 30 * 60 * 1000;
@@ -571,6 +572,41 @@ export class AccountRotator {
       this.log("Could not load state, starting fresh");
     }
     this.loadTokenUsage();
+  }
+
+  private migratePersistedQuotaStateKeys(): void {
+    const foldDeadlines = (deadlines: Record<string, number>) => {
+      const folded: Record<string, number> = {};
+      for (const [key, deadline] of Object.entries(deadlines)) {
+        const canonical = this.resolveQuotaStateKey(key);
+        folded[canonical] = Math.max(folded[canonical] ?? 0, deadline);
+      }
+      return folded;
+    };
+
+    this.modelBreakers = foldDeadlines(this.modelBreakers);
+    const projectBreakers: Record<string, number> = {};
+    for (const [key, deadline] of Object.entries(this.projectModelBreakers)) {
+      const separator = key.lastIndexOf("::");
+      const canonical = separator < 0
+        ? key
+        : projectModelKey(
+            key.slice(0, separator),
+            this.resolveQuotaStateKey(key.slice(separator + 2)),
+          );
+      projectBreakers[canonical] = Math.max(
+        projectBreakers[canonical] ?? 0,
+        deadline,
+      );
+    }
+    this.projectModelBreakers = projectBreakers;
+    this.provider429Events = this.provider429Events.map((event) => ({
+      ...event,
+      modelKey: this.resolveQuotaStateKey(event.modelKey),
+    }));
+    for (const account of this.accounts) {
+      account.cooldownsByModel = foldDeadlines(account.cooldownsByModel);
+    }
   }
 
   private loadTokenUsage(): void {

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -90,11 +90,13 @@ import {
 } from "./rate-limit-parser.js";
 import {
   getAccountIdentity,
+  getCredentialGeneration,
   getProviderCredentialDetails,
 } from "./account-identity.js";
 
 export {
   getAccountIdentity,
+  getCredentialGeneration,
   getProviderCredentialDetails,
 } from "./account-identity.js";
 
@@ -152,18 +154,6 @@ export function areAccountIdentitiesCompatible(
   }
 
   return true;
-}
-
-export function getCredentialGeneration(
-  account: AccountRuntime | AccountConfig,
-  providerId: string,
-): string {
-  const config = "config" in account ? account.config : account;
-  const norm = normalizeAccountConfig(config);
-  const cred = norm.credentials?.find((c) => c.provider === providerId);
-  const details = getProviderCredentialDetails(norm, cred ?? { provider: providerId });
-  if (!cred && !details.secret) return "none";
-  return `${providerId}:${details.projectId}:${details.providerAccountId}:${details.secret}`;
 }
 
 const rotatorLogger = logger.child("rotator");
@@ -359,7 +349,25 @@ export class AccountRotator {
     this.config = applyConfigDefaults(config);
     this.initAccounts();
     this.loadState();
+    this.reconcileDynamicCatalog();
     this.startQuotaPolling();
+  }
+
+  private reconcileDynamicCatalog(): void {
+    dynamicCatalog.retainAccounts(
+      this.accounts
+        .filter(
+          (account) =>
+            !account.disabled &&
+            !account.flagged &&
+            !account.invalidProviders?.[DEFAULT_PROVIDER] &&
+            hasCredential(account.config, DEFAULT_PROVIDER),
+        )
+        .map((account) => ({
+          id: getAccountIdentity(account),
+          generation: getCredentialGeneration(account, DEFAULT_PROVIDER),
+        })),
+    );
   }
 
   private initAccounts(): void {
@@ -860,11 +868,7 @@ export class AccountRotator {
     void this.refreshOllamaCatalogOnce().catch(() => {});
 
     const available = this.accounts.filter((a) => !a.disabled && !a.flagged);
-    dynamicCatalog.retainAccounts(
-      available
-        .filter((account) => hasCredential(account.config, DEFAULT_PROVIDER))
-        .map(getAccountIdentity),
-    );
+    this.reconcileDynamicCatalog();
     let quotaPublished = false;
     for (const account of available) {
       if (await this.pollAccountQuota(account)) {
@@ -1346,9 +1350,10 @@ export class AccountRotator {
     ignoreConcurrency = false,
   ): string | null {
     const projectId = this.getProjectIdForModel(account, modelKey);
-    if (this.isModelBreakerActive(modelKey, now))
+    const quotaStateKey = this.resolveQuotaStateKey(modelKey);
+    if (this.isModelBreakerActive(quotaStateKey, now))
       return "model circuit breaker active";
-    if (this.isProjectModelBreakerActive(projectId, modelKey, now))
+    if (this.isProjectModelBreakerActive(projectId, quotaStateKey, now))
       return "project circuit breaker active";
     if (
       projectId &&
@@ -1427,7 +1432,8 @@ export class AccountRotator {
     const defaultCooldown = account.cooldownsByModel["__default__"] ?? 0;
     if (defaultCooldown > now)
       return { reason: "cooldown", detail: "default cooldown active" };
-    const modelCooldown = account.cooldownsByModel[modelKey] ?? 0;
+    const modelCooldown =
+      account.cooldownsByModel[this.resolveQuotaStateKey(modelKey)] ?? 0;
     if (modelCooldown > now)
       return { reason: "cooldown", detail: "model cooldown active" };
     // Ollama Cloud (pool key "session") imposes no per-account
@@ -2426,7 +2432,7 @@ export class AccountRotator {
   ): void {
     const now = new Date();
     const minuteKey = now.toISOString().slice(0, 16); // "2026-04-28T12:05"
-    const modelKey = model ? resolveDisplayModelKey(model) : "unknown";
+    const modelKey = model ? this.resolveObservedModelKey(model) : "unknown";
 
     // Upsert minute bucket
     let bucket = this.tokenBuckets.minutes.find((b) => b.period === minuteKey);
@@ -2464,7 +2470,7 @@ export class AccountRotator {
     ttfbMs: number,
     totalMs: number,
   ): void {
-    const modelKey = model ? resolveDisplayModelKey(model) : "unknown";
+    const modelKey = model ? this.resolveObservedModelKey(model) : "unknown";
     let records = this.latencyRecords.get(modelKey);
     if (!records) {
       records = [];
@@ -3035,6 +3041,7 @@ export class AccountRotator {
     account.consecutiveErrors++;
     if (account.consecutiveErrors >= 5) {
       account.disabled = true;
+      this.reconcileDynamicCatalog();
       this.log(
         `${account.config.email}: DISABLED after ${account.consecutiveErrors} consecutive errors`,
         "error",
@@ -3058,6 +3065,7 @@ export class AccountRotator {
     account.consecutiveErrors = 0;
     account.lastError = null;
     account.cooldownsByModel = {};
+    this.reconcileDynamicCatalog();
     await this.saveState();
     this.log(`${email}: re-enabled`);
     this.requestWaiterDrain();
@@ -3069,6 +3077,7 @@ export class AccountRotator {
     if (!account) return false;
     account.disabled = true;
     account.lastError = "Disabled by operator";
+    this.reconcileDynamicCatalog();
     await this.saveState();
     this.log(`${email}: disabled by operator`, "warn");
     return true;
@@ -3082,6 +3091,7 @@ export class AccountRotator {
     if (!account) return false;
     account.flagged = true;
     account.lastError = reason;
+    this.reconcileDynamicCatalog();
     await this.saveState();
     this.log(`${email}: quarantined by operator`, "warn");
     return true;
@@ -3094,6 +3104,7 @@ export class AccountRotator {
     account.flagged = false;
     account.consecutiveErrors = 0;
     account.lastError = null;
+    this.reconcileDynamicCatalog();
     await this.saveState();
     this.log(`${email}: restored by operator`, "warn");
     this.requestWaiterDrain();
@@ -3111,6 +3122,7 @@ export class AccountRotator {
       (entry) => entry.email === email,
     );
     if (existing) Object.assign(existing, patch);
+    this.reconcileDynamicCatalog();
     await saveAccountsConfig(this.config);
     await this.saveState();
     this.log(`${email}: metadata updated by operator`, "warn");
@@ -3383,6 +3395,7 @@ export class AccountRotator {
     account.providerTokens ??= {};
     account.providerTokens[providerId] = { accessToken: null, tokenExpires: 0 };
     account.lastError = reason;
+    if (providerId === DEFAULT_PROVIDER) this.reconcileDynamicCatalog();
     this.log(`${account.config.email}: ${providerId} credential requires re-authentication`, "warn");
     this.scheduleStateSave();
   }
@@ -3417,7 +3430,8 @@ export class AccountRotator {
     const providerId = getProviderIdForPoolKey(modelKey);
     if (account.invalidProviders?.[providerId]) return false;
     if ((account.providerCooldowns?.[providerId] ?? 0) > now) return false;
-    const modelCooldown = account.cooldownsByModel[modelKey] ?? 0;
+    const modelCooldown =
+      account.cooldownsByModel[this.resolveQuotaStateKey(modelKey)] ?? 0;
     if (modelCooldown > now) return false;
     // Ollama Cloud (pool key "session") imposes no per-account concurrency
     // limit. Antigravity keeps it so long streams don't pile up on a
@@ -3442,6 +3456,7 @@ export class AccountRotator {
     account.lastError = reason;
     account.inFlightRequests = 0;
     account.inFlightByModel = {};
+    this.reconcileDynamicCatalog();
     this.requestWaiterDrain();
     this.log(`${account.config.email}: FLAGGED - ${reason}`, "error");
     const triggerProtectivePause = options.triggerProtectivePause ?? true;
@@ -3513,6 +3528,11 @@ export class AccountRotator {
     return this.resolveRequestPoolKey(model);
   }
 
+  /** Preserve the exact identity of models learned from the runtime catalog. */
+  resolveObservedModelKey(model: string): string {
+    return dynamicCatalog.getObservedModelId(model) ?? resolveDisplayModelKey(model);
+  }
+
   private resolveRequestPoolKey(model: string): string {
     return this.resolvePoolKeyForModel(model) ?? "__default__";
   }
@@ -3533,6 +3553,12 @@ export class AccountRotator {
     return resolveQuotaModelKey(model) ?? null;
   }
 
+  private resolveQuotaStateKey(modelKey: string): string {
+    return dynamicCatalog.resolveQuotaPool(modelKey) ??
+      resolveQuotaModelKey(modelKey) ??
+      modelKey;
+  }
+
   /** Map a candidate key (model name or pool key) to the account's pool key. */
   private resolvePoolKey(account: AccountRuntime, key: string): string {
     if (
@@ -3549,6 +3575,8 @@ export class AccountRotator {
   private resolveAccountPoolKey(account: AccountRuntime, key: string): string {
     const kickstartPool = QUOTA_POOL_FOR_KICKSTART_MODEL[key];
     if (kickstartPool) return this.resolvePoolKey(account, kickstartPool);
+    const dynamicPool = dynamicCatalog.resolveQuotaPool(key);
+    if (dynamicPool) return this.resolvePoolKey(account, dynamicPool);
     if (
       Object.values(QUOTA_POOL_FOR_KICKSTART_MODEL).includes(key) ||
       account.quota.some((quota) => quota.modelKey === key) ||
@@ -3587,8 +3615,9 @@ export class AccountRotator {
     const modelKey = model
       ? (this.resolvePoolKeyForModel(model) ?? resolveQuotaModelKey(model) ?? "__default__")
       : "__default__";
+    const quotaStateKey = this.resolveQuotaStateKey(modelKey);
     const dailyResetAt = nextUtcDayStartMs(now);
-    const modelBreaker = this.modelBreakers[modelKey] ?? 0;
+    const modelBreaker = this.modelBreakers[quotaStateKey] ?? 0;
     if (modelBreaker > now) retryTimes.push(modelBreaker);
     for (const account of this.accounts) {
       if (account.disabled || account.flagged) continue;
@@ -3604,14 +3633,14 @@ export class AccountRotator {
       if (this.isDailySafetyStopped(account, now))
         retryTimes.push(dailyResetAt);
       const cooldown = Math.max(
-        account.cooldownsByModel[modelKey] ?? 0,
+        account.cooldownsByModel[quotaStateKey] ?? 0,
         account.cooldownsByModel.__default__ ?? 0,
       );
       if (cooldown > now) retryTimes.push(cooldown);
       const projectId = this.getProjectIdForModel(account, modelKey);
       if (projectId) {
         const projectBreaker =
-          this.projectModelBreakers[projectModelKey(projectId, modelKey)] ?? 0;
+          this.projectModelBreakers[projectModelKey(projectId, quotaStateKey)] ?? 0;
         if (projectBreaker > now) retryTimes.push(projectBreaker);
       }
       if ((this.config.routingPolicy || "timer-first") === "hybrid") {
@@ -3882,6 +3911,7 @@ export class AccountRotator {
     const mergedAccounts = normalized.accounts.map(matchAndReuseAccount);
     this.config = { ...normalized, accounts: mergedAccounts.map((account) => account.config) };
     this.accounts = mergedAccounts;
+    this.reconcileDynamicCatalog();
     this.requestWaiterDrain();
     await saveAccountsConfig(this.config);
     await this.saveState();
@@ -3993,6 +4023,7 @@ export class AccountRotator {
       this.log(`${accountConfig.email}: account added via hosted login`);
     }
 
+    this.reconcileDynamicCatalog();
     await saveAccountsConfig(this.config);
     await this.saveState();
     this.requestWaiterDrain();
@@ -4013,6 +4044,7 @@ export class AccountRotator {
     this.accounts.splice(idx, 1);
     const configIdx = this.config.accounts.findIndex((a) => a.email === email);
     if (configIdx >= 0) this.config.accounts.splice(configIdx, 1);
+    this.reconcileDynamicCatalog();
 
     // Fix up modelState indices that may now be stale after the splice
     for (const [, mState] of this.modelState.entries()) {

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -3553,10 +3553,12 @@ export class AccountRotator {
     account: AccountRuntime,
     modelKey: string,
   ): boolean {
+    const accountId = getAccountIdentity(account);
     if (
       !isStaticAntigravityModel(modelKey) &&
-      dynamicCatalog.wasDiscoveredFromLiveCatalog(modelKey) &&
-      !dynamicCatalog.hasModelForAccount(getAccountIdentity(account), modelKey)
+      dynamicCatalog.wasDiscovered(modelKey) &&
+      dynamicCatalog.hasLiveCatalogSnapshot() &&
+      !dynamicCatalog.hasModelForAccount(accountId, modelKey)
     ) {
       return false;
     }

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -3555,7 +3555,7 @@ export class AccountRotator {
   ): boolean {
     if (
       !isStaticAntigravityModel(modelKey) &&
-      dynamicCatalog.wasDiscovered(modelKey) &&
+      dynamicCatalog.wasDiscoveredFromLiveCatalog(modelKey) &&
       !dynamicCatalog.hasModelForAccount(getAccountIdentity(account), modelKey)
     ) {
       return false;
@@ -3581,10 +3581,14 @@ export class AccountRotator {
   }
 
   private resolvePoolKeyForModel(model: string): string | null {
+    const normalizedModel = model.trim().toLowerCase();
     if (
       !isStaticAntigravityModel(model) &&
       dynamicCatalog.wasDiscovered(model)
-    ) return model.toLowerCase();
+    ) return normalizedModel;
+    if (this.hasRelevantQuotaStateForModel(normalizedModel, Date.now())) {
+      return normalizedModel;
+    }
     const context = {
       ollamaModels: this.ollamaModels,
       codexModels: this.codexModels,
@@ -3594,6 +3598,24 @@ export class AccountRotator {
       return adapter.getPoolKey(model);
     }
     return resolveQuotaModelKey(model) ?? null;
+  }
+
+  private hasRelevantQuotaStateForModel(modelKey: string, now: number): boolean {
+    if ((this.modelBreakers[modelKey] ?? 0) > now) return true;
+    if (
+      this.accounts.some(
+        (account) => (account.cooldownsByModel[modelKey] ?? 0) > now,
+      )
+    ) return true;
+    if (
+      Object.entries(this.projectModelBreakers).some(([key, deadline]) =>
+        key.endsWith(`::${modelKey}`) && deadline > now
+      )
+    ) return true;
+    const windowMs = this.config.projectCircuitBreakerWindowMs ?? 10 * 60 * 1000;
+    return this.provider429Events.some(
+      (event) => event.modelKey === modelKey && now - event.ts <= windowMs,
+    );
   }
 
   private resolveQuotaStateKey(modelKey: string): string {

--- a/src/rotator.ts
+++ b/src/rotator.ts
@@ -550,8 +550,8 @@ export class AccountRotator {
         }
       }
       this.migratePersistedQuotaStateKeys();
-      // Cap generic stale cooldowns to 30 min max from now. Antigravity's
-      // explicit Claude/Gemini reset deadlines must survive restarts intact.
+      // Cap explicit generic/non-Google cooldowns to 30 min. An unresolved key
+      // may be a dynamic Google model, so preserve it until catalog hydration.
       const maxCooldown = 30 * 60 * 1000;
       const now = Date.now();
       for (const account of this.accounts) {
@@ -561,6 +561,8 @@ export class AccountRotator {
           if (
             model !== "claude" &&
             model !== "gemini" &&
+            (model === "__default__" ||
+              getProviderIdForPoolKey(model) !== DEFAULT_PROVIDER) &&
             cooldown > now + maxCooldown
           ) {
             account.cooldownsByModel[model] = now + maxCooldown;
@@ -849,6 +851,9 @@ export class AccountRotator {
         try {
           await this.ensureValidTokenForProvider(account, pid);
           await getProviderAdapter(pid).fetchQuota(account, quotaCtx);
+          if (pid === DEFAULT_PROVIDER) {
+            this.migratePersistedQuotaStateKeys();
+          }
           quotaPublished = true;
         } catch {
           // One invalid provider credential must not suppress sibling pools.

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -1221,13 +1221,15 @@ var MODEL_PRICING_CLIENT = {
 function getModelPricingClient(m) {
   if (MODEL_PRICING_CLIENT[m]) return MODEL_PRICING_CLIENT[m];
   var lower = (m || "").toLowerCase();
-  if (lower.indexOf("opus") !== -1) return MODEL_PRICING_CLIENT["claude-opus-4-6-thinking"];
-  if (lower.indexOf("sonnet") !== -1) return MODEL_PRICING_CLIENT["claude-sonnet-4-6"];
-  if (lower.indexOf("3.8-flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.8-flash-high"];
-  if (lower.indexOf("3.7-flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.7-flash-tiered"];
-  if (lower.indexOf("3.6-flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.6-flash-high"];
-  if (lower.indexOf("flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3-flash"];
-  if (lower.indexOf("pro") !== -1) return MODEL_PRICING_CLIENT["gemini-3.1-pro"];
+  if (lower.indexOf("claude") !== -1 && lower.indexOf("opus") !== -1) return MODEL_PRICING_CLIENT["claude-opus-4-6-thinking"];
+  if (lower.indexOf("claude") !== -1 && lower.indexOf("sonnet") !== -1) return MODEL_PRICING_CLIENT["claude-sonnet-4-6"];
+  if (lower.indexOf("gemini") !== -1) {
+    if (lower.indexOf("3.8") !== -1 && lower.indexOf("flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.8-flash-high"];
+    if (lower.indexOf("3.7") !== -1 && lower.indexOf("flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.7-flash-tiered"];
+    if (lower.indexOf("3.6") !== -1 && lower.indexOf("flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3.6-flash-high"];
+    if (lower.indexOf("flash") !== -1) return MODEL_PRICING_CLIENT["gemini-3-flash"];
+    if (lower.indexOf("pro") !== -1) return MODEL_PRICING_CLIENT["gemini-3.1-pro"];
+  }
   if (lower.indexOf("gpt-oss") !== -1) return MODEL_PRICING_CLIENT["gpt-oss-120b-medium"];
   return null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,7 @@ export interface GoogleQuotaResponse {
 export interface ModelSpecConfig {
   maxOutputTokens: number;
   thinkingBudget: number; // -1 = adaptive (model decides), >=0 = fixed
+  minThinkingBudget?: number;
   isThinking: boolean;
 }
 
@@ -849,11 +850,28 @@ export function getModelPricing(model: string): ModelPricing | undefined {
   if (MODEL_PRICING[model]) return MODEL_PRICING[model];
   const lower = model.toLowerCase();
   if (MODEL_PRICING[lower]) return MODEL_PRICING[lower];
-  // Dynamic family fallbacks for unseen future models:
-  if (lower.includes("opus")) return MODEL_PRICING["claude-opus-4-6-thinking"];
-  if (lower.includes("sonnet")) return MODEL_PRICING["claude-sonnet-4-6"];
-  if (lower.includes("flash")) return MODEL_PRICING["gemini-3.8-flash-high"] ?? MODEL_PRICING["gemini-3.7-flash-tiered"];
-  if (lower.includes("pro")) return MODEL_PRICING["gemini-3.1-pro"];
+  // Dynamic family fallbacks for unseen future models. Keep provider and
+  // version checks explicit so an unrelated model containing "flash" cannot
+  // inherit Gemini pricing.
+  if (lower.includes("claude") && lower.includes("opus")) {
+    return MODEL_PRICING["claude-opus-4-6-thinking"];
+  }
+  if (lower.includes("claude") && lower.includes("sonnet")) {
+    return MODEL_PRICING["claude-sonnet-4-6"];
+  }
+  if (lower.includes("gemini")) {
+    if (lower.includes("3.8") && lower.includes("flash")) {
+      return MODEL_PRICING["gemini-3.8-flash-high"];
+    }
+    if (lower.includes("3.7") && lower.includes("flash")) {
+      return MODEL_PRICING["gemini-3.7-flash-tiered"];
+    }
+    if (lower.includes("3.6") && lower.includes("flash")) {
+      return MODEL_PRICING["gemini-3.6-flash-high"];
+    }
+    if (lower.includes("flash")) return MODEL_PRICING["gemini-3-flash"];
+    if (lower.includes("pro")) return MODEL_PRICING["gemini-3.1-pro"];
+  }
   if (lower.includes("gpt-oss")) return MODEL_PRICING["gpt-oss-120b-medium"];
   return undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -455,9 +455,22 @@ export interface PersistedSafetyState {
   }>;
 }
 
+export interface PersistedDynamicModelOwnership {
+  scopedModels: string[];
+  accounts: Record<
+    string,
+    {
+      credentialGenerationFingerprint: string;
+      models: string[];
+    }
+  >;
+}
+
 export interface PersistedState {
   // Historical dynamic model IDs mapped to their shared quota pools.
   dynamicModelQuotaPools?: Record<string, string>;
+  // Exact account ownership for dynamically discovered model IDs.
+  dynamicModelOwnership?: PersistedDynamicModelOwnership;
   // Per-model active account index
   modelAccounts: Record<string, number>;
   // Per-model request count on the active account

--- a/src/types.ts
+++ b/src/types.ts
@@ -456,6 +456,8 @@ export interface PersistedSafetyState {
 }
 
 export interface PersistedState {
+  // Historical dynamic model IDs mapped to their shared quota pools.
+  dynamicModelQuotaPools?: Record<string, string>;
   // Per-model active account index
   modelAccounts: Record<string, number>;
   // Per-model request count on the active account

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -173,6 +173,9 @@ export function validateConfig(value: unknown): ValidationResult<Config> {
 				if (spec.thinkingBudget !== undefined && (typeof spec.thinkingBudget !== "number" || !Number.isFinite(spec.thinkingBudget))) {
 					errors.push(`config.modelSpecs.${key}.thinkingBudget must be a number`);
 				}
+				if (spec.minThinkingBudget !== undefined && !isNonNegativeNumber(spec.minThinkingBudget)) {
+					errors.push(`config.modelSpecs.${key}.minThinkingBudget must be a non-negative number`);
+				}
 				if (spec.isThinking !== undefined && typeof spec.isThinking !== "boolean") {
 					errors.push(`config.modelSpecs.${key}.isThinking must be a boolean`);
 				}

--- a/test/compat-translators.test.ts
+++ b/test/compat-translators.test.ts
@@ -5,9 +5,11 @@ import {
 	anthropicToAntigravityBody,
 	normalizeOpenAIChatCompletionRequest,
 	normalizeOpenAIResponsesRequest,
+	convertResponsesToChatRequest,
 	mapTieredReasoningEffortToThinkingLevel,
 } from "../src/providers/google-antigravity/translators.js";
 import { setModelSpecsOverride } from "../src/compat/model-specs.js";
+import { dynamicCatalog } from "../src/providers/google-antigravity/dynamic-catalog.js";
 
 type AntigravityBodyWithRequest = ReturnType<typeof openAIToAntigravityBody> & {
 	request: {
@@ -310,5 +312,106 @@ describe("mapTieredReasoningEffortToThinkingLevel", () => {
 			mapTieredReasoningEffortToThinkingLevel("high", "gemini-3.6-flash-high"),
 			undefined,
 		);
+	});
+});
+
+describe("dynamic thinking constraints", () => {
+	afterEach(() => {
+		dynamicCatalog.reset();
+	});
+
+	it("honors explicit supportsThinking=false across compatibility protocols", () => {
+		dynamicCatalog.updateFromEndpointResponse({
+			models: {
+				"gemini-4.0-fast": {
+					supportsThinking: false,
+					quotaInfo: { remainingFraction: 1 },
+				},
+			},
+		});
+
+		const requests = [
+			openAIToAntigravityBody({
+				model: "gemini-4.0-fast",
+				messages: [{ role: "user", content: "ping" }],
+				reasoning_effort: "high",
+			}),
+			openAIToAntigravityBody(convertResponsesToChatRequest({
+				model: "gemini-4.0-fast",
+				input: "ping",
+				reasoning: { effort: "high" },
+			}).chatRequest),
+			anthropicToAntigravityBody({
+				model: "gemini-4.0-fast",
+				messages: [{ role: "user", content: "ping" }],
+			}),
+		] as AntigravityBodyWithRequest[];
+
+		for (const request of requests) {
+			assert.equal(request.request.generationConfig?.thinkingConfig, undefined);
+		}
+	});
+
+	it("honors minThinkingBudget consistently across compatibility protocols", () => {
+		dynamicCatalog.updateFromEndpointResponse({
+			models: {
+				"gemini-4.0-min-budget": {
+					maxOutputTokens: 12_000,
+					supportsThinking: true,
+					thinkingBudget: 1_000,
+					minThinkingBudget: 4_000,
+					quotaInfo: { remainingFraction: 1 },
+				},
+			},
+		});
+
+		const requests = [
+			openAIToAntigravityBody({
+				model: "gemini-4.0-min-budget",
+				messages: [{ role: "user", content: "ping" }],
+				max_tokens: 3_000,
+			}),
+			openAIToAntigravityBody(convertResponsesToChatRequest({
+				model: "gemini-4.0-min-budget",
+				input: "ping",
+				max_output_tokens: 3_000,
+			}).chatRequest),
+			anthropicToAntigravityBody({
+				model: "gemini-4.0-min-budget",
+				messages: [{ role: "user", content: "ping" }],
+				max_tokens: 3_000,
+			}),
+		] as AntigravityBodyWithRequest[];
+
+		for (const request of requests) {
+			assert.equal(
+				request.request.generationConfig?.thinkingConfig?.thinkingBudget,
+				4_000,
+			);
+			assert.equal(request.request.generationConfig?.maxOutputTokens, 12_000);
+		}
+	});
+
+	it("never emits a fixed thinking budget that consumes all output tokens", () => {
+		dynamicCatalog.updateFromEndpointResponse({
+			models: {
+				"gemini-4.0-tight-output": {
+					maxOutputTokens: 4_096,
+					supportsThinking: true,
+					thinkingBudget: 5_000,
+					minThinkingBudget: 1_024,
+					quotaInfo: { remainingFraction: 1 },
+				},
+			},
+		});
+
+		const body = openAIToAntigravityBody({
+			model: "gemini-4.0-tight-output",
+			messages: [{ role: "user", content: "ping" }],
+		}) as AntigravityBodyWithRequest;
+		const generation = body.request.generationConfig!;
+		const budget = generation.thinkingConfig?.thinkingBudget as number;
+		assert.ok(Number.isFinite(budget) && budget > 0);
+		assert.ok(budget < generation.maxOutputTokens!);
 	});
 });

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -527,6 +527,11 @@ describe("dashboard", () => {
       getModelPricingClient("google/gemini-3.8-flash-high")?.output,
       3.75,
     );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(getModelPricingClient("google/gemini-4.0-flash-preview"))),
+      { input: 0.5, output: 3.0 },
+    );
+    assert.equal(getModelPricingClient("acme-flash-preview"), null);
 
     const savings = calcSavingsFromBuckets([{
       byModel: {

--- a/test/dynamic-catalog.test.ts
+++ b/test/dynamic-catalog.test.ts
@@ -104,6 +104,90 @@ describe("DynamicModelRegistry", () => {
     assert.deepEqual(dynamicCatalog.getAllModels(), []);
   });
 
+  it("rejects late snapshots after an account leaves the active generation set", () => {
+    dynamicCatalog.retainAccounts([{ id: "account-a", generation: "gen-1" }]);
+    const capturedEpoch = dynamicCatalog.captureAccountEpoch("account-a", "gen-1");
+    assert.equal(typeof capturedEpoch, "number");
+    dynamicCatalog.updateFromEndpointResponse({
+      models: { "gemini-before-removal": { quotaInfo: { remainingFraction: 1 } } },
+    }, "account-a", "gen-1");
+
+    dynamicCatalog.retainAccounts([]);
+    assert.equal(dynamicCatalog.getModel("gemini-before-removal"), undefined);
+    dynamicCatalog.retainAccounts([{ id: "account-a", generation: "gen-1" }]);
+    assert.equal(dynamicCatalog.updateFromEndpointResponse({
+      models: { "gemini-late-after-removal": { quotaInfo: { remainingFraction: 1 } } },
+    }, "account-a", "gen-1", capturedEpoch as number), 0);
+    assert.equal(dynamicCatalog.getModel("gemini-late-after-removal"), undefined);
+  });
+
+  it("never treats quota bucket sentinels as discovered models", () => {
+    const newCount = dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        gemini: { quotaInfo: { remainingFraction: 0.75 } },
+        claude: { quotaInfo: { remainingFraction: 0.5 } },
+        "gemini-real-dynamic-model": { quotaInfo: { remainingFraction: 1 } },
+      },
+    });
+
+    assert.equal(newCount, 1);
+    assert.equal(dynamicCatalog.getModel("gemini"), undefined);
+    assert.equal(dynamicCatalog.getModel("claude"), undefined);
+    assert.equal(dynamicCatalog.wasDiscovered("gemini"), false);
+    assert.equal(dynamicCatalog.wasDiscovered("claude"), false);
+    assert.equal(dynamicCatalog.wasDiscovered("gemini-real-dynamic-model"), true);
+  });
+
+  it("keeps a known-good snapshot when the runtime response is malformed", () => {
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-known-good": { quotaInfo: { remainingFraction: 1 } },
+      },
+    }, "account-a");
+
+    assert.equal(dynamicCatalog.updateFromEndpointResponse(
+      { models: null } as unknown as GoogleQuotaResponse,
+      "account-a",
+    ), 0);
+    assert.ok(dynamicCatalog.getModel("gemini-known-good"));
+
+    assert.equal(dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-null-entry": null,
+        "gemini-array-entry": [],
+      },
+      tieredModelIds: {
+        invalid: [null, 42],
+      },
+    } as unknown as GoogleQuotaResponse, "account-a"), 0);
+    assert.ok(dynamicCatalog.getModel("gemini-known-good"));
+  });
+
+  it("skips malformed entries and non-finite metadata without losing valid models", () => {
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-null-entry": null,
+        "gemini-valid-entry": {
+          maxTokens: Number.POSITIVE_INFINITY,
+          maxOutputTokens: Number.NaN,
+          thinkingBudget: Number.POSITIVE_INFINITY,
+          quotaInfo: { remainingFraction: 0.5 },
+        },
+      },
+      tieredModelIds: {
+        invalid: [null, 42, ""],
+      },
+    } as unknown as GoogleQuotaResponse);
+
+    assert.equal(dynamicCatalog.getModel("gemini-null-entry"), undefined);
+    assert.deepEqual(getModelSpec("gemini-valid-entry"), {
+      maxOutputTokens: 65536,
+      thinkingBudget: 24576,
+      isThinking: true,
+      contextWindow: 1_000_000,
+    });
+  });
+
   it("preserves Gemini family defaults for quota-only dynamic metadata", () => {
     dynamicCatalog.updateFromEndpointResponse({
       models: {
@@ -126,6 +210,34 @@ describe("DynamicModelRegistry", () => {
       maxOutputTokens: 32768,
       thinkingConfig: { includeThoughts: true, thinkingBudget: 24576 },
     });
+  });
+
+  it("seeds sparse known models from their exact static specs", () => {
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "claude-sonnet-4-5": { quotaInfo: { remainingFraction: 0.75 } },
+      },
+    });
+
+    assert.deepEqual(getModelSpec("claude-sonnet-4-5"), {
+      maxOutputTokens: 64000,
+      thinkingBudget: 32768,
+      isThinking: true,
+      contextWindow: 200_000,
+    });
+  });
+
+  it("keeps historical quota-pool provenance after a dynamic model disappears", () => {
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-ephemeral-vnext": { quotaInfo: { remainingFraction: 1 } },
+      },
+    }, "account-a");
+    dynamicCatalog.updateFromEndpointResponse({ models: {} }, "account-a");
+
+    assert.equal(dynamicCatalog.getModel("gemini-ephemeral-vnext"), undefined);
+    assert.equal(dynamicCatalog.wasDiscovered("gemini-ephemeral-vnext"), true);
+    assert.equal(dynamicCatalog.resolveQuotaPool("gemini-ephemeral-vnext"), "gemini");
   });
 
   it("exposes dynamic model specs through getModelSpec", () => {
@@ -226,8 +338,8 @@ describe("DynamicModelRegistry", () => {
     // Unlisted future Flash model falls back to Flash pricing
     const flashPrice = getModelPricing("gemini-4.5-flash-hyper");
     assert.ok(flashPrice);
-    assert.equal(flashPrice.inputPer1M, 0.75);
-    assert.equal(flashPrice.outputPer1M, 3.75);
+    assert.equal(flashPrice.inputPer1M, 0.5);
+    assert.equal(flashPrice.outputPer1M, 3.0);
 
     // Unlisted future Pro model falls back to Pro pricing
     const proPrice = getModelPricing("gemini-5.0-pro-ultra");

--- a/test/dynamic-catalog.test.ts
+++ b/test/dynamic-catalog.test.ts
@@ -163,6 +163,24 @@ describe("DynamicModelRegistry", () => {
     assert.ok(dynamicCatalog.getModel("gemini-known-good"));
   });
 
+  it("rejects prototype-sensitive model IDs without replacing a known-good snapshot", () => {
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-known-good": { quotaInfo: { remainingFraction: 1 } },
+      },
+    }, "account-a");
+    const unsafe = JSON.parse(
+      '{"models":{"__proto__":{"quotaInfo":{"remainingFraction":1}}}}',
+    ) as GoogleQuotaResponse;
+
+    assert.equal(
+      dynamicCatalog.updateFromEndpointResponse(unsafe, "account-a"),
+      0,
+    );
+    assert.ok(dynamicCatalog.getModel("gemini-known-good"));
+    assert.equal(dynamicCatalog.wasDiscovered("__proto__"), false);
+  });
+
   it("skips malformed entries and non-finite metadata without losing valid models", () => {
     dynamicCatalog.updateFromEndpointResponse({
       models: {
@@ -287,6 +305,51 @@ describe("DynamicModelRegistry", () => {
         thinkingBudget: 6789,
         isThinking: true,
         contextWindow: 222222,
+      });
+    } finally {
+      setModelSpecsOverride(null);
+    }
+  });
+
+  it("uses runtime constraints for bundled IDs unless an operator overrides them", () => {
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-3.8-flash-high": {
+          maxOutputTokens: 2048,
+          supportsThinking: false,
+          quotaInfo: { remainingFraction: 1 },
+        },
+      },
+    });
+
+    assert.deepEqual(getModelSpec("gemini-3.8-flash-high"), {
+      maxOutputTokens: 2048,
+      thinkingBudget: -1,
+      isThinking: false,
+      contextWindow: 1_000_000,
+    });
+    const runtimeBody = openAIToAntigravityBody({
+      model: "gemini-3.8-flash-high",
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 10_000,
+    }) as { request: { generationConfig?: Record<string, unknown> } };
+    assert.equal(runtimeBody.request.generationConfig?.maxOutputTokens, 2048);
+    assert.equal(runtimeBody.request.generationConfig?.thinkingConfig, undefined);
+
+    setModelSpecsOverride({
+      "gemini-3.8": {
+        maxOutputTokens: 4096,
+        thinkingBudget: 1000,
+        isThinking: true,
+        contextWindow: 500_000,
+      },
+    });
+    try {
+      assert.deepEqual(getModelSpec("gemini-3.8-flash-high"), {
+        maxOutputTokens: 4096,
+        thinkingBudget: 1000,
+        isThinking: true,
+        contextWindow: 500_000,
       });
     } finally {
       setModelSpecsOverride(null);

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -166,6 +166,54 @@ describe("model discovery", () => {
 		}
 	});
 
+	it("publishes dynamic output and thinking metadata without using the context window as output", () => {
+		dynamicCatalog.updateFromEndpointResponse({
+			models: {
+				"gemini-4.0-flash-thinking": {
+					maxTokens: 2_000_000,
+					maxOutputTokens: 32_000,
+					supportsThinking: true,
+					thinkingBudget: 12_000,
+					minThinkingBudget: 2_000,
+					quotaInfo: { remainingFraction: 1 },
+				},
+			},
+		});
+		try {
+			const openAiPayload = captureJson(serveOpenAIModels) as {
+				data: Array<{ id: string; meta: Record<string, unknown> }>;
+			};
+			const openAiEntry = openAiPayload.data.find(
+				(model) => model.id === "gemini-4.0-flash-thinking",
+			);
+			assert.ok(openAiEntry);
+			assert.equal(openAiEntry.meta.max_output_tokens, 32_000);
+			assert.equal(openAiEntry.meta.thinking, true);
+			assert.equal(openAiEntry.meta.thinking_budget, 12_000);
+			assert.equal(openAiEntry.meta.min_thinking_budget, 2_000);
+
+			const geminiPayload = captureJson(serveGeminiModels) as {
+				models: Array<{
+					name: string;
+					inputTokenLimit: number;
+					outputTokenLimit: number;
+					capabilities: Record<string, unknown>;
+				}>;
+			};
+			const geminiEntry = geminiPayload.models.find(
+				(model) => model.name === "models/gemini-4.0-flash-thinking",
+			);
+			assert.ok(geminiEntry);
+			assert.equal(geminiEntry.inputTokenLimit, 2_000_000);
+			assert.equal(geminiEntry.outputTokenLimit, 32_000);
+			assert.equal(geminiEntry.capabilities.thinking, true);
+			assert.equal(geminiEntry.capabilities.thinkingBudget, 12_000);
+			assert.equal(geminiEntry.capabilities.minThinkingBudget, 2_000);
+		} finally {
+			dynamicCatalog.reset();
+		}
+	});
+
 	it("ships the exact default spec for gemini-3.7-flash-tiered", () => {
 		assert.deepEqual(getModelSpec("gemini-3.7-flash-tiered"), {
 			maxOutputTokens: 65536,

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { serveGeminiModels, serveOpenAIModels } from "../src/compat.js";
-import { getModelSpec } from "../src/compat/model-specs.js";
+import { getModelSpec, setModelSpecsOverride } from "../src/compat/model-specs.js";
 import { dynamicCatalog } from "../src/providers/google-antigravity/dynamic-catalog.js";
 
 function captureJson(render: (res: never) => void): unknown {
@@ -210,6 +210,68 @@ describe("model discovery", () => {
 			assert.equal(geminiEntry.capabilities.thinkingBudget, 12_000);
 			assert.equal(geminiEntry.capabilities.minThinkingBudget, 2_000);
 		} finally {
+			dynamicCatalog.reset();
+		}
+	});
+
+	it("publishes operator-overridden effective specs for dynamic models", () => {
+		dynamicCatalog.updateFromEndpointResponse({
+			models: {
+				"gemini-4.0-operator-model": {
+					maxTokens: 2_000_000,
+					maxOutputTokens: 32_000,
+					supportsThinking: false,
+					quotaInfo: { remainingFraction: 1 },
+				},
+			},
+		});
+		setModelSpecsOverride({
+			"gemini-4.0": {
+				maxOutputTokens: 7000,
+				thinkingBudget: 2000,
+				minThinkingBudget: 1000,
+				isThinking: true,
+				contextWindow: 300_000,
+			},
+		});
+
+		try {
+			const openAiPayload = captureJson(serveOpenAIModels) as {
+				data: Array<{
+					id: string;
+					context_window: number;
+					meta: Record<string, unknown>;
+				}>;
+			};
+			const openAiEntry = openAiPayload.data.find(
+				(model) => model.id === "gemini-4.0-operator-model",
+			);
+			assert.ok(openAiEntry);
+			assert.equal(openAiEntry.context_window, 300_000);
+			assert.equal(openAiEntry.meta.max_output_tokens, 7000);
+			assert.equal(openAiEntry.meta.thinking, true);
+			assert.equal(openAiEntry.meta.thinking_budget, 2000);
+			assert.equal(openAiEntry.meta.min_thinking_budget, 1000);
+
+			const geminiPayload = captureJson(serveGeminiModels) as {
+				models: Array<{
+					name: string;
+					inputTokenLimit: number;
+					outputTokenLimit: number;
+					capabilities: Record<string, unknown>;
+				}>;
+			};
+			const geminiEntry = geminiPayload.models.find(
+				(model) => model.name === "models/gemini-4.0-operator-model",
+			);
+			assert.ok(geminiEntry);
+			assert.equal(geminiEntry.inputTokenLimit, 300_000);
+			assert.equal(geminiEntry.outputTokenLimit, 7000);
+			assert.equal(geminiEntry.capabilities.thinking, true);
+			assert.equal(geminiEntry.capabilities.thinkingBudget, 2000);
+			assert.equal(geminiEntry.capabilities.minThinkingBudget, 1000);
+		} finally {
+			setModelSpecsOverride(null);
 			dynamicCatalog.reset();
 		}
 	});

--- a/test/model-resolution.test.ts
+++ b/test/model-resolution.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
 	MODEL_PRICING,
 	QUOTA_MODEL_KEYS,
+	getModelPricing,
 	resolveDisplayModelKey,
 	resolveQuotaModelKey,
 } from "../src/types.js";
@@ -212,6 +213,33 @@ describe("model resolution", () => {
 		assert.equal(gemini.percentRemaining, 42);
 		// No other pool key present in the stub response.
 		assert.equal(quotas.length, 1);
+	});
+
+	it("skips metadata-only family entries and uses the first quota-bearing sibling", () => {
+		const quotas = extractQuotas({
+			models: {
+				"gemini-future-metadata-only": { displayName: "metadata only" },
+				"gemini-future-exhausted": {
+					quotaInfo: { remainingFraction: 0 },
+				},
+				"gemini-future-available": {
+					quotaInfo: { remainingFraction: 0.9 },
+				},
+			},
+		}, []);
+
+		assert.deepEqual(quotas.map(({ modelKey, percentRemaining }) => ({
+			modelKey,
+			percentRemaining,
+		})), [{ modelKey: "gemini", percentRemaining: 0 }]);
+	});
+
+	it("uses provider-aware versioned Gemini pricing fallbacks", () => {
+		assert.equal(getModelPricing("google/gemini-3.8-flash-preview")?.inputPer1M, 0.75);
+		assert.equal(getModelPricing("google/gemini-3.7-flash-preview")?.inputPer1M, 0.75);
+		assert.equal(getModelPricing("google/gemini-3.6-flash-preview")?.inputPer1M, 1.5);
+		assert.equal(getModelPricing("google/gemini-4.0-flash-preview")?.inputPer1M, 0.5);
+		assert.equal(getModelPricing("acme-flash-preview"), undefined);
 	});
 
 	it("treats intact Google quota as fresh even when reset times are present", () => {

--- a/test/model-resolution.test.ts
+++ b/test/model-resolution.test.ts
@@ -234,6 +234,27 @@ describe("model resolution", () => {
 		})), [{ modelKey: "gemini", percentRemaining: 0 }]);
 	});
 
+	it("ignores malformed canonical quota and uses a valid family sibling", () => {
+		const quotas = extractQuotas({
+			models: {
+				gemini: {
+					quotaInfo: {
+						remainingFraction: 2,
+						resetTime: "2099-01-01T00:00:00Z",
+					},
+				},
+				"gemini-valid-sibling": {
+					quotaInfo: { remainingFraction: 0.9 },
+				},
+			},
+		}, []);
+
+		assert.deepEqual(quotas.map(({ modelKey, percentRemaining }) => ({
+			modelKey,
+			percentRemaining,
+		})), [{ modelKey: "gemini", percentRemaining: 90 }]);
+	});
+
 	it("uses provider-aware versioned Gemini pricing fallbacks", () => {
 		assert.equal(getModelPricing("google/gemini-3.8-flash-preview")?.inputPer1M, 0.75);
 		assert.equal(getModelPricing("google/gemini-3.7-flash-preview")?.inputPer1M, 0.75);

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -13,7 +13,11 @@ import {
   type RequestBody,
 } from "../src/proxy.js";
 import { ANTIGRAVITY_ENDPOINTS, type AccountRuntime } from "../src/types.js";
-import { getAccountIdentity, type AccountRotator } from "../src/rotator.js";
+import {
+	getAccountIdentity,
+	getCredentialGeneration,
+	type AccountRotator,
+} from "../src/rotator.js";
 import { fetchProviderQuota } from "../src/providers/google-antigravity/quota.js";
 import { dynamicCatalog } from "../src/providers/google-antigravity/dynamic-catalog.js";
 
@@ -934,6 +938,52 @@ describe("native Code Assist passthrough", () => {
 			assert.ok(dynamicCatalog.getModel("gemini-valid-after-bad-entry"));
 			assert.equal(account.quota[0]?.percentRemaining, 60);
 		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("ignores a stale quota 401 after replacement credentials arrive during body read", async () => {
+		const account = makeAccount("stale-quota-error@example.com", "shared-project");
+		const accountId = getAccountIdentity(account);
+		const generation = getCredentialGeneration(account, "google-antigravity");
+		dynamicCatalog.retainAccounts([{ id: accountId, generation }]);
+
+		let announceBodyRead!: () => void;
+		const bodyRead = new Promise<void>((resolve) => {
+			announceBodyRead = resolve;
+		});
+		let releaseBodyRead!: () => void;
+		const bodyGate = new Promise<void>((resolve) => {
+			releaseBodyRead = resolve;
+		});
+		const response = new Response("stale credentials", { status: 401 });
+		response.text = async () => {
+			announceBodyRead();
+			await bodyGate;
+			return "stale credentials";
+		};
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => response) as typeof fetch;
+		const effects: string[] = [];
+
+		try {
+			const poll = fetchProviderQuota(account, {
+				log: () => effects.push("log"),
+				reportQuotaPollFlag: () => effects.push("report"),
+				markFlagged: () => effects.push("flag"),
+			});
+			await bodyRead;
+			account.config.refreshToken = "replacement-refresh-token";
+			dynamicCatalog.retainAccounts([{
+				id: getAccountIdentity(account),
+				generation: getCredentialGeneration(account, "google-antigravity"),
+			}]);
+			releaseBodyRead();
+			await poll;
+
+			assert.deepEqual(effects, []);
+		} finally {
+			releaseBodyRead();
 			globalThis.fetch = originalFetch;
 		}
 	});

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -881,6 +881,63 @@ describe("native Code Assist passthrough", () => {
 		}
 	});
 
+	it("keeps quota polling usable when runtime catalog entries are malformed", async () => {
+		const account = makeAccount("malformed-catalog@example.com", "project-safe");
+		account.quota = [{
+			modelKey: "gemini",
+			displayName: "Gemini",
+			percentRemaining: 80,
+			resetTime: null,
+			timerType: "fresh",
+			providerId: "google-antigravity",
+		}];
+		const accountId = getAccountIdentity(account);
+		dynamicCatalog.updateFromEndpointResponse({
+			models: {
+				"gemini-known-good-before-malformed": {
+					quotaInfo: { remainingFraction: 0.8 },
+				},
+			},
+		}, accountId);
+
+		const responses: unknown[] = [
+			{ models: null },
+			{
+				models: {
+					"gemini-bad-null-entry": null,
+					"gemini-valid-after-bad-entry": {
+						maxTokens: null,
+						quotaInfo: { remainingFraction: 0.6 },
+					},
+				},
+				tieredModelIds: { bad: [null, 42, ""] },
+			},
+		];
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => new Response(
+			JSON.stringify(responses.shift()),
+			{ status: 200, headers: { "Content-Type": "application/json" } },
+		)) as typeof fetch;
+		const ctx = {
+			log: () => {},
+			markFlagged: () => {},
+			reportQuotaPollFlag: () => {},
+		};
+
+		try {
+			await fetchProviderQuota(account, ctx);
+			assert.ok(dynamicCatalog.getModel("gemini-known-good-before-malformed"));
+			assert.equal(account.quota[0]?.percentRemaining, 80);
+
+			await fetchProviderQuota(account, ctx);
+			assert.equal(dynamicCatalog.getModel("gemini-bad-null-entry"), undefined);
+			assert.ok(dynamicCatalog.getModel("gemini-valid-after-bad-entry"));
+			assert.equal(account.quota[0]?.percentRemaining, 60);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	it("rejects invalid payloads and unknown operations before upstream forwarding", async () => {
 		let upstreamCalls = 0;
 		const upstream = await listen((req, res) => {

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -942,6 +942,44 @@ describe("native Code Assist passthrough", () => {
 		}
 	});
 
+	it("preserves the last Google quota snapshot when a successful poll has no usable rows", async () => {
+		const account = makeAccount("malformed-quota@example.com", "project-safe");
+		account.quota = [{
+			modelKey: "gemini",
+			displayName: "Gemini",
+			percentRemaining: 80,
+			resetTime: null,
+			timerType: "fresh",
+			providerId: "google-antigravity",
+		}];
+		const originalQuota = structuredClone(account.quota);
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => new Response(JSON.stringify({
+			models: {
+				gemini: {
+					quotaInfo: {
+						remainingFraction: 2,
+						resetTime: "2099-01-01T00:00:00Z",
+					},
+				},
+			},
+		}), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		})) as typeof fetch;
+
+		try {
+			await fetchProviderQuota(account, {
+				log: () => {},
+				markFlagged: () => {},
+				reportQuotaPollFlag: () => {},
+			});
+			assert.deepEqual(account.quota, originalQuota);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	it("ignores a stale quota 401 after replacement credentials arrive during body read", async () => {
 		const account = makeAccount("stale-quota-error@example.com", "shared-project");
 		const accountId = getAccountIdentity(account);

--- a/test/proxy-e2e.test.ts
+++ b/test/proxy-e2e.test.ts
@@ -944,6 +944,7 @@ describe("native Code Assist passthrough", () => {
 
 	it("preserves the last Google quota snapshot when a successful poll has no usable rows", async () => {
 		const account = makeAccount("malformed-quota@example.com", "project-safe");
+		const accountId = getAccountIdentity(account);
 		account.quota = [{
 			modelKey: "gemini",
 			displayName: "Gemini",
@@ -952,6 +953,14 @@ describe("native Code Assist passthrough", () => {
 			timerType: "fresh",
 			providerId: "google-antigravity",
 		}];
+		dynamicCatalog.updateFromEndpointResponse({
+			defaultAgentModelId: "future-known-good",
+			models: {
+				"future-known-good": {
+					quotaInfo: { remainingFraction: 0.8 },
+				},
+			},
+		}, accountId);
 		const originalQuota = structuredClone(account.quota);
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = (async () => new Response(JSON.stringify({
@@ -975,6 +984,12 @@ describe("native Code Assist passthrough", () => {
 				reportQuotaPollFlag: () => {},
 			});
 			assert.deepEqual(account.quota, originalQuota);
+			assert.ok(dynamicCatalog.getModel("future-known-good"));
+			assert.equal(
+				dynamicCatalog.hasModelForAccount(accountId, "future-known-good"),
+				true,
+			);
+			assert.equal(dynamicCatalog.getDefaultAgentModelId(), "future-known-good");
 		} finally {
 			globalThis.fetch = originalFetch;
 		}

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -310,16 +310,17 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
     const email = "restored-neutral-routing@example.com";
     const projectId = "restored-neutral-routing-project";
     const originalFetch = globalThis.fetch;
+    let quotaResponse: unknown = {
+      models: {
+        [rawModel]: { quotaInfo: { remainingFraction: 1 } },
+      },
+    };
     let firstRotator: InstanceType<typeof AccountRotator> | undefined;
     let secondRotator: InstanceType<typeof AccountRotator> | undefined;
 
     dynamicCatalog.reset();
     await setCachedState({ modelAccounts: {}, accounts: {} });
-    globalThis.fetch = (async () => new Response(JSON.stringify({
-      models: {
-        [rawModel]: { quotaInfo: { remainingFraction: 1 } },
-      },
-    }), {
+    globalThis.fetch = (async () => new Response(JSON.stringify(quotaResponse), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     })) as typeof fetch;
@@ -351,6 +352,18 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
       const selected = await (secondRotator as any).tryGetActiveAccount(rawModel);
       assert.equal(selected, secondAccount);
       secondRotator.finishRequest(secondAccount, rawModel);
+
+      quotaResponse = {
+        models: {
+          gemini: { quotaInfo: { remainingFraction: 1 } },
+        },
+      };
+      await secondRotator.pollAccountQuota(secondAccount);
+      assert.equal(dynamicCatalog.getModel(rawModel), undefined);
+      assert.equal(
+        await (secondRotator as any).tryGetActiveAccount(rawModel),
+        null,
+      );
     } finally {
       firstRotator?.stopQuotaPolling();
       secondRotator?.stopQuotaPolling();

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -228,6 +228,80 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
     }
   });
 
+  it("folds persisted raw dynamic safety keys into shared quota pools", async () => {
+    const now = Date.now();
+    const canonicalDeadline = now + 20 * 60 * 1000;
+    const rawDeadline = now + 2 * 60 * 60 * 1000;
+    const rawModel = "gemini-4.0-flash-preview";
+    const email = "persisted-dynamic-state@example.com";
+    const projectId = "persisted-dynamic-project";
+
+    await setCachedState({
+      modelAccounts: {},
+      safety: {
+        day: new Date(now).toISOString().slice(0, 10),
+        projectRequests: {},
+        modelBreakers: {
+          gemini: canonicalDeadline,
+          [rawModel]: rawDeadline,
+        },
+        projectModelBreakers: {
+          [`${projectId}::gemini`]: canonicalDeadline,
+          [`${projectId}::${rawModel}`]: rawDeadline,
+        },
+        provider429Events: [
+          { ts: now - 2000, projectId, modelKey: rawModel, account: email },
+          { ts: now - 1000, projectId, modelKey: "gemini", account: email },
+        ],
+      },
+      accounts: {
+        [email]: {
+          totalRequests: 0,
+          cooldownsByModel: {
+            gemini: canonicalDeadline,
+            [rawModel]: rawDeadline,
+          },
+          quotaExhaustedAt: now,
+          disabled: false,
+          flagged: false,
+        },
+      },
+    });
+
+    try {
+      const rotator = new AccountRotator({
+        proxyPort: 51224,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [{ email, projectId, refreshToken: "persisted-refresh" }],
+      }) as any;
+      rotator.stopQuotaPolling();
+      const restored = rotator.accounts[0] as AccountRuntime;
+
+      assert.equal(restored.cooldownsByModel.gemini, rawDeadline);
+      assert.equal(restored.cooldownsByModel[rawModel], undefined);
+      assert.equal(rotator.modelBreakers.gemini, rawDeadline);
+      assert.equal(rotator.modelBreakers[rawModel], undefined);
+      assert.equal(
+        rotator.projectModelBreakers[`${projectId}::gemini`],
+        rawDeadline,
+      );
+      assert.equal(
+        rotator.projectModelBreakers[`${projectId}::${rawModel}`],
+        undefined,
+      );
+      assert.equal(rotator.provider429Events.length, 2);
+      assert.ok(
+        rotator.provider429Events.every(
+          (event: { modelKey: string }) => event.modelKey === "gemini",
+        ),
+      );
+    } finally {
+      await setCachedState({ modelAccounts: {}, accounts: {} });
+    }
+  });
+
   it("rotateModel and activateModelAccount do not leak in-flight counters during background polling", async () => {
     const acc1 = makeAccount("acc1@example.com", "shared-project", "claude", 100);
     const acc2 = makeAccount("acc2@example.com", "shared-project", "claude", 100);

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -305,6 +305,166 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
     }
   });
 
+  it("routes a restored neutral dynamic model before its first post-restart poll", async () => {
+    const rawModel = "future-vnext";
+    const email = "restored-neutral-routing@example.com";
+    const projectId = "restored-neutral-routing-project";
+    const originalFetch = globalThis.fetch;
+    let firstRotator: InstanceType<typeof AccountRotator> | undefined;
+    let secondRotator: InstanceType<typeof AccountRotator> | undefined;
+
+    dynamicCatalog.reset();
+    await setCachedState({ modelAccounts: {}, accounts: {} });
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      models: {
+        [rawModel]: { quotaInfo: { remainingFraction: 1 } },
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+    try {
+      const config = {
+        proxyPort: 51224,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [{ email, projectId, refreshToken: "persisted-refresh" }],
+      };
+      firstRotator = new AccountRotator(config);
+      firstRotator.stopQuotaPolling();
+      const firstAccount = (firstRotator as any).accounts[0] as AccountRuntime;
+      firstAccount.accessToken = "first-access-token";
+      firstAccount.tokenExpires = Date.now() + 60_000;
+      await firstRotator.pollAccountQuota(firstAccount);
+      await firstRotator.saveState();
+
+      dynamicCatalog.reset();
+      secondRotator = new AccountRotator(config);
+      secondRotator.stopQuotaPolling();
+      const secondAccount = (secondRotator as any).accounts[0] as AccountRuntime;
+      secondAccount.accessToken = "second-access-token";
+      secondAccount.tokenExpires = Date.now() + 60_000;
+
+      assert.equal(dynamicCatalog.resolveQuotaPool(rawModel), "gemini");
+      const selected = await (secondRotator as any).tryGetActiveAccount(rawModel);
+      assert.equal(selected, secondAccount);
+      secondRotator.finishRequest(secondAccount, rawModel);
+    } finally {
+      firstRotator?.stopQuotaPolling();
+      secondRotator?.stopQuotaPolling();
+      dynamicCatalog.reset();
+      globalThis.fetch = originalFetch;
+      await setCachedState({ modelAccounts: {}, accounts: {} });
+    }
+  });
+
+  it("honors legacy neutral dynamic safety state before catalog hydration", async () => {
+    const now = Date.now();
+    const rawModel = "future-vnext";
+    const email = "legacy-neutral-safety@example.com";
+    const projectId = "legacy-neutral-safety-project";
+    const deadline = now + 2 * 60 * 60 * 1000;
+    const originalFetch = globalThis.fetch;
+    let rotator: InstanceType<typeof AccountRotator> | undefined;
+
+    dynamicCatalog.reset();
+    await setCachedState({
+      modelAccounts: {},
+      safety: {
+        day: new Date(now).toISOString().slice(0, 10),
+        projectRequests: {},
+        modelBreakers: { [rawModel]: deadline },
+        projectModelBreakers: { [`${projectId}::${rawModel}`]: deadline },
+        provider429Events: [
+          { ts: now - 2_000, projectId, modelKey: rawModel, account: "legacy-a@example.com" },
+          { ts: now - 1_000, projectId, modelKey: rawModel, account: "legacy-b@example.com" },
+        ],
+      },
+      accounts: {
+        [email]: {
+          totalRequests: 0,
+          cooldownsByModel: { [rawModel]: deadline },
+          quotaExhaustedAt: now,
+          disabled: false,
+          flagged: false,
+        },
+      },
+    });
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      models: {
+        [rawModel]: { quotaInfo: { remainingFraction: 1 } },
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+    try {
+      rotator = new AccountRotator({
+        proxyPort: 51224,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        projectCircuitBreaker429Threshold: 3,
+        modelCircuitBreaker429Threshold: 3,
+        accounts: [{ email, projectId, refreshToken: "persisted-refresh" }],
+      });
+      rotator.stopQuotaPolling();
+      const account = (rotator as any).accounts[0] as AccountRuntime;
+      account.accessToken = "legacy-access-token";
+      account.tokenExpires = deadline;
+
+      assert.equal((rotator as any).resolveRequestPoolKey(rawModel), rawModel);
+      assert.equal((rotator as any).isAvailableForModel(account, rawModel, now), false);
+
+      delete account.cooldownsByModel[rawModel];
+      assert.equal(
+        (rotator as any).getUnavailableReasonForModel(account, rawModel, now),
+        "model circuit breaker active",
+      );
+      delete (rotator as any).modelBreakers[rawModel];
+      assert.equal(
+        (rotator as any).getUnavailableReasonForModel(account, rawModel, now),
+        "project circuit breaker active",
+      );
+      delete (rotator as any).projectModelBreakers[`${projectId}::${rawModel}`];
+
+      rotator.recordProvider429(account, rawModel, 1_000);
+      assert.ok((rotator as any).modelBreakers[rawModel] > now);
+      assert.equal((rotator as any).provider429Events.length, 3);
+      assert.ok(
+        (rotator as any).provider429Events.every(
+          (event: { modelKey: string }) => event.modelKey === rawModel,
+        ),
+      );
+      account.cooldownsByModel[rawModel] = deadline;
+      (rotator as any).projectModelBreakers[`${projectId}::${rawModel}`] = deadline;
+
+      await rotator.pollAccountQuota(account);
+      assert.equal(account.cooldownsByModel[rawModel], undefined);
+      assert.equal(account.cooldownsByModel.gemini, deadline);
+      assert.equal((rotator as any).modelBreakers[rawModel], undefined);
+      assert.ok((rotator as any).modelBreakers.gemini > now);
+      assert.equal(
+        (rotator as any).projectModelBreakers[`${projectId}::${rawModel}`],
+        undefined,
+      );
+      assert.ok((rotator as any).projectModelBreakers[`${projectId}::gemini`] > now);
+      assert.ok(
+        (rotator as any).provider429Events.every(
+          (event: { modelKey: string }) => event.modelKey === "gemini",
+        ),
+      );
+    } finally {
+      rotator?.stopQuotaPolling();
+      dynamicCatalog.reset();
+      globalThis.fetch = originalFetch;
+      await setCachedState({ modelAccounts: {}, accounts: {} });
+    }
+  });
+
   it("preserves a neutral dynamic cooldown across discovery and restart", async () => {
     const now = Date.now();
     const canonicalDeadline = now + 20 * 60 * 1000;

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -31,6 +31,7 @@ let isDbConfigured: typeof import("../src/db-store.js").isDbConfigured;
 let setCachedState: typeof import("../src/db-store.js").setCachedState;
 let getAccountsPath: typeof import("../src/paths.js").getAccountsPath;
 let getProviderAdapter: typeof import("../src/providers/registry.js").getProviderAdapter;
+let dynamicCatalog: typeof import("../src/providers/google-antigravity/dynamic-catalog.js").dynamicCatalog;
 type AccountRuntime = import("../src/types.js").AccountRuntime;
 
 before(async () => {
@@ -38,6 +39,7 @@ before(async () => {
   const rotatorMod = await import("../src/rotator.js");
   const pathsMod = await import("../src/paths.js");
   const regMod = await import("../src/providers/registry.js");
+  const catalogMod = await import("../src/providers/google-antigravity/dynamic-catalog.js");
 
   initDb = dbStore.initDb;
   closeDb = dbStore.closeDb;
@@ -46,6 +48,7 @@ before(async () => {
   AccountRotator = rotatorMod.AccountRotator;
   getAccountsPath = pathsMod.getAccountsPath;
   getProviderAdapter = regMod.getProviderAdapter;
+  dynamicCatalog = catalogMod.dynamicCatalog;
 
   // Verify hermetic file-based isolation
   assert.ok(
@@ -298,6 +301,106 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
         ),
       );
     } finally {
+      await setCachedState({ modelAccounts: {}, accounts: {} });
+    }
+  });
+
+  it("preserves a neutral dynamic cooldown across discovery and restart", async () => {
+    const now = Date.now();
+    const canonicalDeadline = now + 20 * 60 * 1000;
+    const rawDeadline = now + 2 * 60 * 60 * 1000;
+    const rawModel = "future-vnext";
+    const email = "persisted-neutral-dynamic@example.com";
+    const projectId = "persisted-neutral-project";
+    const originalFetch = globalThis.fetch;
+    let firstRotator: InstanceType<typeof AccountRotator> | undefined;
+    let secondRotator: InstanceType<typeof AccountRotator> | undefined;
+
+    dynamicCatalog.reset();
+    await setCachedState({
+      modelAccounts: {},
+      safety: {
+        day: new Date(now).toISOString().slice(0, 10),
+        projectRequests: {},
+        modelBreakers: { gemini: canonicalDeadline, [rawModel]: rawDeadline },
+        projectModelBreakers: {
+          [`${projectId}::gemini`]: canonicalDeadline,
+          [`${projectId}::${rawModel}`]: rawDeadline,
+        },
+        provider429Events: [
+          { ts: now - 1000, projectId, modelKey: rawModel, account: email },
+        ],
+      },
+      accounts: {
+        [email]: {
+          totalRequests: 0,
+          cooldownsByModel: { gemini: canonicalDeadline, [rawModel]: rawDeadline },
+          quotaExhaustedAt: now,
+          disabled: false,
+          flagged: false,
+        },
+      },
+    });
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      models: {
+        [rawModel]: { quotaInfo: { remainingFraction: 1 } },
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+    try {
+      const config = {
+        proxyPort: 51224,
+        rotateOnQuotaDrop: 20,
+        quotaPollIntervalMs: 300000,
+        requestsPerRotation: 5,
+        accounts: [{ email, projectId, refreshToken: "persisted-refresh" }],
+      };
+      firstRotator = new AccountRotator(config);
+      firstRotator.stopQuotaPolling();
+      const firstAccount = (firstRotator as any).accounts[0] as AccountRuntime;
+      firstAccount.accessToken = "restored-access-token";
+      firstAccount.tokenExpires = rawDeadline;
+
+      assert.equal(firstAccount.cooldownsByModel[rawModel], rawDeadline);
+      await firstRotator.pollAccountQuota(firstAccount);
+      assert.equal(firstAccount.cooldownsByModel.gemini, rawDeadline);
+      assert.equal(firstAccount.cooldownsByModel[rawModel], undefined);
+      assert.equal((firstRotator as any).modelBreakers.gemini, rawDeadline);
+      assert.equal(
+        (firstRotator as any).projectModelBreakers[`${projectId}::gemini`],
+        rawDeadline,
+      );
+      assert.equal(
+        (firstRotator as any).provider429Events[0]?.modelKey,
+        "gemini",
+      );
+      assert.equal(
+        (firstRotator as any).isAvailableForModel(firstAccount, rawModel, now),
+        false,
+      );
+      await firstRotator.saveState();
+
+      dynamicCatalog.reset();
+      secondRotator = new AccountRotator(config);
+      secondRotator.stopQuotaPolling();
+      const secondAccount = (secondRotator as any).accounts[0] as AccountRuntime;
+      assert.equal(secondAccount.cooldownsByModel.gemini, rawDeadline);
+      assert.equal(secondAccount.cooldownsByModel[rawModel], undefined);
+      secondAccount.accessToken = "reloaded-access-token";
+      secondAccount.tokenExpires = rawDeadline;
+      await secondRotator.pollAccountQuota(secondAccount);
+      assert.equal(
+        (secondRotator as any).isAvailableForModel(secondAccount, rawModel, now),
+        false,
+      );
+    } finally {
+      firstRotator?.stopQuotaPolling();
+      secondRotator?.stopQuotaPolling();
+      dynamicCatalog.reset();
+      globalThis.fetch = originalFetch;
       await setCachedState({ modelAccounts: {}, accounts: {} });
     }
   });

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -28,10 +28,13 @@ let AccountRotator: typeof import("../src/rotator.js").AccountRotator;
 let initDb: typeof import("../src/db-store.js").initDb;
 let closeDb: typeof import("../src/db-store.js").closeDb;
 let isDbConfigured: typeof import("../src/db-store.js").isDbConfigured;
+let getCachedState: typeof import("../src/db-store.js").getCachedState;
 let setCachedState: typeof import("../src/db-store.js").setCachedState;
 let getAccountsPath: typeof import("../src/paths.js").getAccountsPath;
 let getProviderAdapter: typeof import("../src/providers/registry.js").getProviderAdapter;
 let dynamicCatalog: typeof import("../src/providers/google-antigravity/dynamic-catalog.js").dynamicCatalog;
+let getAccountIdentity: typeof import("../src/rotator.js").getAccountIdentity;
+let getCredentialGeneration: typeof import("../src/rotator.js").getCredentialGeneration;
 type AccountRuntime = import("../src/types.js").AccountRuntime;
 
 before(async () => {
@@ -44,8 +47,11 @@ before(async () => {
   initDb = dbStore.initDb;
   closeDb = dbStore.closeDb;
   isDbConfigured = dbStore.isDbConfigured;
+  getCachedState = dbStore.getCachedState;
   setCachedState = dbStore.setCachedState;
   AccountRotator = rotatorMod.AccountRotator;
+  getAccountIdentity = rotatorMod.getAccountIdentity;
+  getCredentialGeneration = rotatorMod.getCredentialGeneration;
   getAccountsPath = pathsMod.getAccountsPath;
   getProviderAdapter = regMod.getProviderAdapter;
   dynamicCatalog = catalogMod.dynamicCatalog;
@@ -369,6 +375,144 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
       secondRotator?.stopQuotaPolling();
       dynamicCatalog.reset();
       globalThis.fetch = originalFetch;
+      await setCachedState({ modelAccounts: {}, accounts: {} });
+    }
+  });
+
+  it("restores dynamic model ownership by complete account identity", async () => {
+    const modelA = "future-a-only";
+    const modelB = "future-b-only";
+    const sharedEmail = "restored-ownership@example.com";
+    const accounts = [
+      {
+        email: sharedEmail,
+        credentials: [{
+          provider: "google-antigravity" as const,
+          projectId: "restored-project-a",
+          refreshToken: "restored-secret-a",
+        }],
+      },
+      {
+        email: sharedEmail,
+        credentials: [{
+          provider: "google-antigravity" as const,
+          projectId: "restored-project-b",
+          refreshToken: "restored-secret-b",
+        }],
+      },
+    ];
+    const config = {
+      proxyPort: 51224,
+      rotateOnQuotaDrop: 20,
+      quotaPollIntervalMs: 300000,
+      requestsPerRotation: 5,
+      accounts,
+    };
+    let firstRotator: InstanceType<typeof AccountRotator> | undefined;
+    let secondRotator: InstanceType<typeof AccountRotator> | undefined;
+    let changedRotator: InstanceType<typeof AccountRotator> | undefined;
+
+    dynamicCatalog.reset();
+    await setCachedState({ modelAccounts: {}, accounts: {} });
+
+    try {
+      firstRotator = new AccountRotator(config);
+      firstRotator.stopQuotaPolling();
+      const firstAccounts = (firstRotator as any).accounts as AccountRuntime[];
+      const accountAId = getAccountIdentity(firstAccounts[0]);
+      const accountBId = getAccountIdentity(firstAccounts[1]);
+      assert.notEqual(accountAId, accountBId);
+
+      dynamicCatalog.updateFromEndpointResponse({
+        models: { [modelA]: { quotaInfo: { remainingFraction: 1 } } },
+      }, accountAId);
+      dynamicCatalog.updateFromEndpointResponse({
+        models: { [modelB]: { quotaInfo: { remainingFraction: 1 } } },
+      }, accountBId);
+      (firstRotator as any).modelState.set(modelA, {
+        activeAccountIndex: 1,
+        quotaAtRotationStart: -1,
+        requestsOnActiveAccount: 0,
+      });
+      (firstRotator as any).modelState.set(modelB, {
+        activeAccountIndex: 0,
+        quotaAtRotationStart: -1,
+        requestsOnActiveAccount: 0,
+      });
+      await firstRotator.saveState();
+      const persisted = getCachedState();
+
+      dynamicCatalog.reset();
+      secondRotator = new AccountRotator(config);
+      secondRotator.stopQuotaPolling();
+      const secondAccounts = (secondRotator as any).accounts as AccountRuntime[];
+      for (const [index, account] of secondAccounts.entries()) {
+        account.accessToken = `second-access-${index}`;
+        account.tokenExpires = Date.now() + 60_000;
+      }
+
+      const selectedA = await (secondRotator as any).tryGetActiveAccount(modelA);
+      assert.equal(selectedA, secondAccounts[0]);
+      secondRotator.finishRequest(selectedA, modelA);
+
+      const ownership = (persisted as any)?.dynamicModelOwnership;
+      assert.deepEqual(
+        Object.keys(ownership.accounts).sort(),
+        [accountAId, accountBId].sort(),
+      );
+      const serializedOwnership = JSON.stringify(ownership);
+      assert.equal(serializedOwnership.includes("restored-secret-a"), false);
+      assert.equal(serializedOwnership.includes("restored-secret-b"), false);
+
+      dynamicCatalog.updateFromEndpointResponse({
+        models: { [modelA]: { quotaInfo: { remainingFraction: 1 } } },
+      }, accountAId, getCredentialGeneration(secondAccounts[0], "google-antigravity"));
+      const selectedB = await (secondRotator as any).tryGetActiveAccount(modelB);
+      assert.equal(selectedB, secondAccounts[1]);
+      secondRotator.finishRequest(selectedB, modelB);
+
+      dynamicCatalog.updateFromEndpointResponse(
+        { models: {} },
+        accountAId,
+        getCredentialGeneration(secondAccounts[0], "google-antigravity"),
+      );
+      assert.equal(
+        await (secondRotator as any).tryGetActiveAccount(modelA),
+        null,
+      );
+
+      dynamicCatalog.reset();
+      changedRotator = new AccountRotator({
+        ...config,
+        accounts: [
+          {
+            ...accounts[0],
+            credentials: [{
+              ...accounts[0].credentials[0],
+              refreshToken: "replacement-secret-a",
+            }],
+          },
+          accounts[1],
+        ],
+      });
+      changedRotator.stopQuotaPolling();
+      const changedAccounts = (changedRotator as any).accounts as AccountRuntime[];
+      for (const [index, account] of changedAccounts.entries()) {
+        account.accessToken = `changed-access-${index}`;
+        account.tokenExpires = Date.now() + 60_000;
+      }
+      assert.equal(
+        await (changedRotator as any).tryGetActiveAccount(modelA),
+        null,
+      );
+      const unchangedB = await (changedRotator as any).tryGetActiveAccount(modelB);
+      assert.equal(unchangedB, changedAccounts[1]);
+      changedRotator.finishRequest(unchangedB, modelB);
+    } finally {
+      firstRotator?.stopQuotaPolling();
+      secondRotator?.stopQuotaPolling();
+      changedRotator?.stopQuotaPolling();
+      dynamicCatalog.reset();
       await setCachedState({ modelAccounts: {}, accounts: {} });
     }
   });

--- a/test/rotator-429-resilience.test.ts
+++ b/test/rotator-429-resilience.test.ts
@@ -391,6 +391,15 @@ describe("429 RESOURCE_EXHAUSTED resilience and in-flight lifecycle", () => {
       assert.equal(secondAccount.cooldownsByModel[rawModel], undefined);
       secondAccount.accessToken = "reloaded-access-token";
       secondAccount.tokenExpires = rawDeadline;
+      assert.equal(dynamicCatalog.resolveQuotaPool(rawModel), "gemini");
+      assert.equal(
+        (secondRotator as any).isAvailableForModel(secondAccount, rawModel, now),
+        false,
+      );
+      assert.equal(
+        await (secondRotator as any).tryGetActiveAccount(rawModel),
+        null,
+      );
       await secondRotator.pollAccountQuota(secondAccount);
       assert.equal(
         (secondRotator as any).isAvailableForModel(secondAccount, rawModel, now),

--- a/test/rotator-request-queue.test.ts
+++ b/test/rotator-request-queue.test.ts
@@ -223,6 +223,156 @@ describe("Antigravity request queue", () => {
     );
   });
 
+  it("uses the shared quota pool for dynamic-model cooldown state", () => {
+    const { rotator, accounts } = makeRotator(["project-a"]);
+    const model = "gemini-4.0-flash-preview";
+    dynamicCatalog.updateFromEndpointResponse({
+      models: { [model]: { quotaInfo: { remainingFraction: 1 } } },
+    }, getAccountIdentity(accounts[0]));
+
+    rotator.markExhausted(accounts[0], model, 60_000, "RESOURCE_EXHAUSTED");
+
+    assert.ok(accounts[0].cooldownsByModel.gemini > Date.now());
+    assert.equal(accounts[0].cooldownsByModel[model], undefined);
+    assert.equal(
+      (rotator as any).isAvailableForModel(
+        accounts[0],
+        "gemini-3.8-flash-high",
+        Date.now(),
+      ),
+      false,
+    );
+  });
+
+  it("preserves active and historical dynamic IDs in observability", () => {
+    const { rotator, accounts } = makeRotator(["project-a"]);
+    const model = "gemini-4.0-flash-preview";
+    const accountId = getAccountIdentity(accounts[0]);
+    dynamicCatalog.updateFromEndpointResponse({
+      models: { [model]: { quotaInfo: { remainingFraction: 1 } } },
+    }, accountId);
+
+    rotator.recordTokenUsage(model, 10, 20);
+    rotator.recordLatency(model, 5, 15);
+    dynamicCatalog.updateFromEndpointResponse({ models: {} }, accountId);
+    rotator.recordTokenUsage(model, 30, 40);
+    rotator.recordLatency(model, 10, 20);
+
+    const usage = rotator.getTokenUsage();
+    assert.deepEqual(usage.tokensByModel[model], {
+      input: 40,
+      output: 60,
+      requests: 2,
+    });
+    assert.equal(usage.tokensByModel["gemini-3-flash"], undefined);
+    assert.equal(rotator.getLatencyStats()[model]?.count, 2);
+  });
+
+  it("synchronously removes dynamic snapshots when an account becomes ineligible", async () => {
+    const { rotator, accounts } = makeRotatorFromAccounts([{
+      email: "catalog-disable@example.com",
+      credentials: [{
+        provider: "google-antigravity",
+        projectId: "project-a",
+        refreshToken: "catalog-disable-refresh",
+      }],
+    }]);
+    const accountId = getAccountIdentity(accounts[0]);
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-disabled-account-only": { quotaInfo: { remainingFraction: 1 } },
+      },
+    }, accountId);
+    assert.ok(dynamicCatalog.getModel("gemini-disabled-account-only"));
+
+    const disabling = rotator.disableAccount(accounts[0].config.email);
+    assert.equal(dynamicCatalog.getModel("gemini-disabled-account-only"), undefined);
+    await disabling;
+  });
+
+  it("synchronously removes dynamic snapshots when an account is removed", async () => {
+    const { rotator, accounts } = makeRotatorFromAccounts([{
+      email: "catalog-remove@example.com",
+      credentials: [{
+        provider: "google-antigravity",
+        projectId: "project-a",
+        refreshToken: "catalog-remove-refresh",
+      }],
+    }]);
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-removed-account-only": { quotaInfo: { remainingFraction: 1 } },
+      },
+    }, getAccountIdentity(accounts[0]));
+
+    const removing = rotator.removeAccount(accounts[0].config.email);
+    assert.equal(dynamicCatalog.getModel("gemini-removed-account-only"), undefined);
+    assert.equal(await removing, true);
+  });
+
+  it("rejects a late quota snapshot after the account credential generation changes", async () => {
+    const { rotator, accounts } = makeRotatorFromAccounts([{
+      email: "catalog-race@example.com",
+      credentials: [{
+        provider: "google-antigravity",
+        projectId: "project-a",
+        refreshToken: "catalog-race-refresh",
+      }],
+    }]);
+    const account = accounts[0];
+    const accountId = getAccountIdentity(account);
+    dynamicCatalog.updateFromEndpointResponse({
+      models: {
+        "gemini-before-reconfigure": { quotaInfo: { remainingFraction: 1 } },
+      },
+    }, accountId);
+
+    let releaseFetch!: () => void;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    let announceFetch!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => {
+      announceFetch = resolve;
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      announceFetch();
+      await fetchGate;
+      return new Response(JSON.stringify({
+        models: {
+          "gemini-stale-in-flight": { quotaInfo: { remainingFraction: 1 } },
+        },
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as typeof fetch;
+
+    try {
+      const poll = rotator.pollAccountQuota(account);
+      await fetchStarted;
+      await rotator.replaceConfig({
+        ...rotator.getConfig(),
+        accounts: [{
+          ...account.config,
+          credentials: [{
+            provider: "google-antigravity",
+            projectId: "project-a",
+            refreshToken: "replacement-refresh-token",
+          }],
+        }],
+      });
+      const removedSynchronously =
+        dynamicCatalog.getModel("gemini-before-reconfigure") === undefined;
+
+      releaseFetch();
+      await poll;
+      assert.equal(removedSynchronously, true);
+      assert.equal(dynamicCatalog.getModel("gemini-stale-in-flight"), undefined);
+    } finally {
+      releaseFetch();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("defaults to five total concurrent requests per account and project/model", () => {
     const config = getDefaultConfig();
     assert.equal(config.maxConcurrentRequestsPerAccount, 5);

--- a/test/spend-logger.test.ts
+++ b/test/spend-logger.test.ts
@@ -96,11 +96,11 @@ test("logSpend uses dynamic family pricing in detailed cost metadata", () => {
     });
 
     assert.deepEqual(getSpendQueueItemsForTests()[0].metadata?.costBreakdown, {
-      promptCostUsd: 0.75,
-      completionCostUsd: 3.75,
-      totalCostUsd: 4.5,
-      inputRatePer1M: 0.75,
-      outputRatePer1M: 3.75,
+      promptCostUsd: 0.5,
+      completionCostUsd: 3,
+      totalCostUsd: 3.5,
+      inputRatePer1M: 0.5,
+      outputRatePer1M: 3,
     });
   } finally {
     if (origDb === undefined) delete process.env.DATABASE_URL;


### PR DESCRIPTION
## Summary

Follow-up to #29. This fixes confirmed regressions found after the dynamic catalog was merged:

- select only quota entries with a valid remaining fraction, preserve exhausted siblings, and update quota/catalog state transactionally so malformed-only polls retain both last-known-good quota and per-account catalog/default metadata
- reconcile catalogs immediately across account removal, disablement, and credential changes, rejecting every stale in-flight response side effect
- exclude retired models, reserved quota buckets, malformed entries, and prototype-sensitive IDs without replacing known-good snapshots
- keep exact dynamic model identity for availability and observability while sharing quota/cooldown state through the family pool
- persist and validate account-scoped dynamic-model ownership by complete stable account identity and credential-generation fingerprint, without persisting raw secrets, so cold restarts cannot route one account's model through another account
- separate restored historical provenance from live account-scoped availability so restored models route before the first poll while models removed by a live snapshot stay unavailable
- preserve legacy neutral cooldown, breaker, and 429 state before catalog hydration, then fold it into the discovered family pool without shortening deadlines or losing history
- publish effective output-token and thinking metadata, honoring operator overrides and active runtime constraints before bundled defaults
- seed sparse known models from static specs and normalize thinking budgets across Chat, Responses, and Anthropic requests
- restore provider-aware, version-aware Gemini pricing fallbacks in the server and dashboard

## Verification

- `npm run check`
- 725 tests passed
- source and test typechecks passed
- lint passed with 15 pre-existing warnings and no errors
- `git diff --check`
- focused regressions: 155 routing/catalog tests passed
